### PR TITLE
Bump pako from 1.0.11 to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@pdf-lib/standard-fonts": "^1.0.0",
     "@pdf-lib/upng": "^1.0.1",
-    "pako": "^1.0.11",
+    "pako": "^2.0.3",
     "tslib": "^1.11.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,
referring to #[689](https://github.com/Hopding/pdf-lib/issues/689), and taking into account that types for pako did not change you can bump dependency. I have tested that lib still builds.

In order to fix #689, you have to fork other abandoned libraries:
https://github.com/Hopding/standard-fonts/pull/2
https://github.com/Hopding/upng/pull/1