### PR TITLE
Add font style and font weight to runnersToPage

### DIFF
--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -160,15 +160,30 @@ const runnersToPage = (
     const fontSize = element.svgAttributes.fontSize || 12;
     const fontStyle = element.svgAttributes.fontStyle
       ? `_${element.svgAttributes.fontStyle}`
-      : '';
+      : ' '; // adding this space ensures that .find in fontsFallbacks will not return a false positive
     const fontWeight = element.svgAttributes.fontWeight
       ? `_${element.svgAttributes.fontWeight}`
-      : '';
-    const svgFont = element.svgAttributes.fontFamily
-      ? element.svgAttributes.fontFamily + fontWeight + fontStyle
+      : ' ';
+    const fontFamily = element.svgAttributes.fontFamily;
+    const svgFont = fontFamily
+      ? fontFamily + fontWeight.trimRight() + fontStyle.trimRight()
       : undefined;
 
-    const font = options.fonts && svgFont ? options.fonts[svgFont] : undefined;
+    const fontsFallbacks = [
+      svgFont || '',
+      fontFamily + fontWeight,
+      fontFamily + fontStyle,
+      fontFamily || '',
+    ];
+
+    const font =
+      options.fonts && svgFont
+        ? options.fonts[
+            fontsFallbacks.find(
+              (fontFallback) => options.fonts![fontFallback],
+            ) || ''
+          ]
+        : undefined;
     const textWidth = (font || page.getFont()[0]).widthOfTextAtSize(
       text,
       fontSize,
@@ -246,7 +261,7 @@ const runnersToPage = (
       switch (command) {
         case 'm':
         case 'M': {
-          const isLocalInstruction = command === command.toLocaleLowerCase()
+          const isLocalInstruction = command === command.toLocaleLowerCase();
           const nextPoint = new Point({
             x: (isLocalInstruction ? origin.x : basePoint.x) + params[0],
             y: (isLocalInstruction ? origin.y : basePoint.y) + params[1],
@@ -340,17 +355,17 @@ const runnersToPage = (
         case 'C': {
           const isLocalInstruction = command === 'c';
 
-          let x = 0
-          let y = 0
+          let x = 0;
+          let y = 0;
 
           for (
             let pendingParams = params;
             pendingParams.length > 0;
             pendingParams = pendingParams.slice(6)
           ) {
-            const [, , , , pendingX, pendingY] = pendingParams
-            x += pendingX
-            y += pendingY
+            const [, , , , pendingX, pendingY] = pendingParams;
+            x += pendingX;
+            y += pendingY;
           }
 
           const nextPoint = new Point({
@@ -367,17 +382,17 @@ const runnersToPage = (
         case 'S':
           const isLocalInstruction = command === 's';
 
-          let x = 0
-          let y = 0
+          let x = 0;
+          let y = 0;
 
           for (
             let pendingParams = params;
             pendingParams.length > 0;
             pendingParams = pendingParams.slice(4)
           ) {
-            const [, , pendingX, pendingY] = pendingParams
-            x += pendingX
-            y += pendingY
+            const [, , pendingX, pendingY] = pendingParams;
+            x += pendingX;
+            y += pendingY;
           }
 
           const nextPoint = new Point({
@@ -420,7 +435,9 @@ const runnersToPage = (
       ?.map((command) => {
         const letter = command.match(/[a-z]/i)?.[0];
         const params = command
-          .match(/(-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?)|(-?\.[0-9]+(e[+-]?[0-9]+)?)|(-?[0-9]+)/gi)
+          .match(
+            /(-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?)|(-?\.[0-9]+(e[+-]?[0-9]+)?)|(-?[0-9]+)/gi,
+          )
           ?.filter((m) => m !== '')
           .map((v) => parseFloat(v));
         if (letter && params) {
@@ -812,7 +829,9 @@ const parseAttributes = (
         if (letter?.toLocaleLowerCase() === 'z') return letter;
         // const params = command.match(/([0-9e.-]+)/ig)?.filter(m => m !== '')//.map(v => parseFloat(v))
         const params = command
-          .match(/(-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?)|(-?\.[0-9]+(e[+-]?[0-9]+)?)|([0-9]+)/gi)
+          .match(
+            /(-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?)|(-?\.[0-9]+(e[+-]?[0-9]+)?)|([0-9]+)/gi,
+          )
           ?.filter((m) => m !== ''); // .map(v => parseFloat(v))
 
         if (!params) return letter || '';


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->
This modification allows the `runnersToPage` function consider the font weight and style.

## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->
Without this modification, when using a styled font (italic and/or bold), the only attributed read from svg is `font-family`, while both `font-style` and `font-weight` are not considered.

## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->
Both `font-weight` and `font-style` are read from the svg attributes using `styleOrAttibute`.  
In `runnersToPage` these attributes are formatted and added to the font, resulting in a string like: `fontFamily_weight_style`. 

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->
Testing was done using a set of svg with and without styles and weights.


## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->

## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->
| Before | After |
| ------- | ------|
| <img width="258" alt="image" src="https://user-images.githubusercontent.com/6175382/197874783-26e7bc14-2ef5-4d52-b94f-a257802dec65.png"> | <img width="275" alt="image" src="https://user-images.githubusercontent.com/6175382/197875072-d545d5cf-a448-4c0f-bd0e-dbd2b0c21738.png"> |
  

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->

## Anything Else?
<!-- Please share any additional notes here. -->

## Checklist
- [ ] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [ ] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [ ] My changes work for both **new** and **existing** PDF files.
- [ ] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
