### PR TITLE
Fix runnersToPage to clear the text content before computing the text…

### DIFF
--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -560,7 +560,7 @@ const runnersToPage = (
 ): SVGElementToDrawMap => ({
   async text(element) {
     const anchor = element.svgAttributes.textAnchor;
-    const text = element.text;
+    const text = element.text.trim().replace(/\s/g, ' ');
     const fontSize = element.svgAttributes.fontSize || 12;
 
     /** This will find the best font for the provided style in the list */


### PR DESCRIPTION
This issue was happening when there was a '\n' characters on the text tag
![image](https://user-images.githubusercontent.com/42742621/224817864-a68d4b91-e875-4269-b81c-42c5d16ebcc1.png)

also, the text was drawn on the wrong place when there were spaces before the text.