### PR TITLE
fix parseAttributes to handle width and height equal to 0

### DIFF
--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -1000,8 +1000,8 @@ const parseAttributes = (
   }
   if (attributes.width || attributes.height) {
     const size = newConverter.size(
-      width || inherited.width,
-      height || inherited.height,
+      width ?? inherited.width,
+      height ?? inherited.height,
     );
     svgAttributes.width = size.width;
     svgAttributes.height = size.height;


### PR DESCRIPTION
When the element had a width equals to 0 it was using parent's width instead of its own.