### PR TITLE
Fix drawSvg to respect the drawig order of each element

### DIFF
--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1562,14 +1562,14 @@ export default class PDFPage {
    * @param svg The SVG to be drawn.
    * @param options The options to be used when drawing the SVG.
    */
-  drawSvg(svg: string, options: PDFPageDrawSVGElementOptions = {}): void {
+  async drawSvg(svg: string, options: PDFPageDrawSVGElementOptions = {}): Promise<void> {
     assertIs(svg, 'svg', ['string']);
     assertOrUndefined(options.x, 'options.x', ['number']);
     assertOrUndefined(options.y, 'options.y', ['number']);
     assertOrUndefined(options.width, 'options.width', ['number']);
     assertOrUndefined(options.height, 'options.height', ['number']);
 
-    drawSvg(this, svg, {
+    await drawSvg(this, svg, {
       x: options.x ?? this.x,
       y: options.y ?? this.y,
       fonts: options.fonts,

--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -1549,5 +1549,9 @@ export const drawSvg = async (
 
   const runners = runnersToPage(page, options);
   const elements = parse(firstChild.outerHTML, options, size, defaultConverter);
-  elements.forEach((elt) => runners[elt.tagName]?.(elt));
+
+  await elements.reduce(async (prev, elt) => {
+    await prev
+    return runners[elt.tagName]?.(elt)
+  }, Promise.resolve());
 };


### PR DESCRIPTION
The issue was related to drawing SVG that contains images. Since images needs to be embedded before the drawing, its code is asynchronous. The previous code was allowing the next elements to be drawn before the image, so they were overlapped by the image.
