### PR TITLE
Fix duplicate adjustment in SVG path command T

### DIFF
--- a/src/api/svgPath.ts
+++ b/src/api/svgPath.ts
@@ -273,8 +273,6 @@ const runners: CmdToOperatorsMap = {
     }
 
     const cmd = appendQuadraticCurve(px, py, a[0], a[1]);
-    px = cx - (px - cx);
-    py = cy - (py - cy);
     cx = a[0];
     cy = a[1];
     return cmd;

--- a/tests/api/svgPath.spec.ts
+++ b/tests/api/svgPath.spec.ts
@@ -139,4 +139,15 @@ describe(`svgPathToOperators`, () => {
       '100 100 m,100 100 100 200 v,100 300 200 200 v,90 120 m,90 120 90 220 v,90 320 190 220 v',
     );
   });
+
+  it(`correctly updates control points for T command`, () => {
+    // See https://github.com/Hopding/pdf-lib/issues/1443
+    const operators = svgPathToOperators(
+      'M 10,25 Q 30,0 50,25 Q 70,50 90,25 T 130,25 T 170,25',
+    );
+    expect(operators.length).toBe(5);
+    expect(operators.toString()).toBe(
+      '10 25 m,30 0 50 25 v,70 50 90 25 v,110 0 130 25 v,150 50 170 25 v'
+    );
+  });
 });


### PR DESCRIPTION
The control point (`px`, `py`) is already updated in the else branch above (L271). It is then updated once again which causes https://github.com/Hopding/pdf-lib/issues/1443

This commit removes these duplicated lines which fixes the bug.

<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->
Fixes https://github.com/Hopding/pdf-lib/issues/1443

## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->
Because we're making the world a better place.

## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->
See code. Removed two lines of code which were clearly wrong.

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->
I've come across this issue cheating when I implemented SVG path support in [PDF Maker](https://github.com/eclipsesource/pdf-maker).

As explained in the bug mentioned above, with this path: `M 10,25 Q 30,0 50,25 Q 70,50 90,25 T 130,25 T 170,25`, the green line in the image below should be rendered, but the red line actually is.

To reprocude, try `drawSvgPath('M 10,25 Q 30,0 50,25 Q 70,50 90,25 T 130,25 T 170,25')`

## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->
No.

## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->
![image](https://user-images.githubusercontent.com/255637/233854412-1710fd15-7749-43fd-a910-0c4211ff9a5e.png)

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->
Unrelated, but yes, I've read most of the PDF 1.7 spec :nerd_face:  

## Anything Else?
<!-- Please share any additional notes here. -->
Thanks for keeping this project alive, guys! :heart: 

## Checklist
- [ ] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
  TLDR, sorry
- [ ] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [x] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [x] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [ ] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
  Sorry, I'm not a `yarn` guy. But your CI checks that, doesn't it?