### PR TITLE
Made polygons croppable

### DIFF
--- a/apps/web/test27.html
+++ b/apps/web/test27.html
@@ -82,6 +82,201 @@
     <circle r="3" cx="786.359375" cy="299.9166666666667" fill="red" />
 </svg>`;
 
+      const cutArrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="104 88.828125 217 217" alt=" " width="217" height="217" id="7d9b6377-21db-4e9c-9c83-7519454de3f5" class="r-maxHeight-pm9dpa r-maxWidth-dnmrzs r-pointerEvents-633pao" style="height: 217px; width: 217px;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="440" height="396" viewBox="-10 -9.075 20 18.15" x="0" y="0">
+      <g transform="scale(1 -1) translate(0 0)">
+      <line id="gridX:1" x1="1" x2="1" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:2" x1="2" x2="2" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:3" x1="3" x2="3" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:4" x1="4" x2="4" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:5" x1="5" x2="5" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:6" x1="6" x2="6" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:7" x1="7" x2="7" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:8" x1="8" x2="8" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridX:9" x1="9" x2="9" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-1" x1="-1" x2="-1" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-2" x1="-2" x2="-2" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-3" x1="-3" x2="-3" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-4" x1="-4" x2="-4" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-5" x1="-5" x2="-5" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-6" x1="-6" x2="-6" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-7" x1="-7" x2="-7" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-8" x1="-8" x2="-8" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridx:-9" x1="-9" x2="-9" y1="-9.075" y2="9.075" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:1" x1="-10" x2="10" y1="1" y2="1" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:2" x1="-10" x2="10" y1="2" y2="2" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:3" x1="-10" x2="10" y1="3" y2="3" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:4" x1="-10" x2="10" y1="4" y2="4" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:5" x1="-10" x2="10" y1="5" y2="5" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:6" x1="-10" x2="10" y1="6" y2="6" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:7" x1="-10" x2="10" y1="7" y2="7" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:8" x1="-10" x2="10" y1="8" y2="8" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:9" x1="-10" x2="10" y1="9" y2="9" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-1" x1="-10" x2="10" y1="-1" y2="-1" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-2" x1="-10" x2="10" y1="-2" y2="-2" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-3" x1="-10" x2="10" y1="-3" y2="-3" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-4" x1="-10" x2="10" y1="-4" y2="-4" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-5" x1="-10" x2="10" y1="-5" y2="-5" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-6" x1="-10" x2="10" y1="-6" y2="-6" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-7" x1="-10" x2="10" y1="-7" y2="-7" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-8" x1="-10" x2="10" y1="-8" y2="-8" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<line id="gridy:-9" x1="-10" x2="10" y1="-9" y2="-9" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#E5E5E5"></line>
+<g id="xAxis"><line id="xAxis-line" x1="-10" x2="10" y1="0" y2="0" stroke-width="0.09999999999999999" stroke-linecap="round" stroke="#000000"></line><polygon points="9.538060233744357,-0.19134171618254492 9.538060233744357,0.19134171618254492 10,0" fill="#000000" stroke="#000000" stroke-width="0.09999999999999999"></polygon>
+  </g>
+<line id="xGrad:1" x1="1" x2="1" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:1" transform="translate(1 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:1-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">1</text>
+  </g>
+<line id="xGrad:2" x1="2" x2="2" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:2" transform="translate(2 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:2-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">2</text>
+  </g>
+<line id="xGrad:3" x1="3" x2="3" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:3" transform="translate(3 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:3-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">3</text>
+  </g>
+<line id="xGrad:4" x1="4" x2="4" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:4" transform="translate(4 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:4-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">4</text>
+  </g>
+<line id="xGrad:5" x1="5" x2="5" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:5" transform="translate(5 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:5-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">5</text>
+  </g>
+<line id="xGrad:6" x1="6" x2="6" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:6" transform="translate(6 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:6-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">6</text>
+  </g>
+<line id="xGrad:7" x1="7" x2="7" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:7" transform="translate(7 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:7-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">7</text>
+  </g>
+<line id="xGrad:8" x1="8" x2="8" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:8" transform="translate(8 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:8-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">8</text>
+  </g>
+<line id="xGrad:9" x1="9" x2="9" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:9" transform="translate(9 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:9-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">9</text>
+  </g>
+<line id="xGrad:-1" x1="-1" x2="-1" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-1" transform="translate(-1 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-1-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-1</text>
+  </g>
+<line id="xGrad:-2" x1="-2" x2="-2" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-2" transform="translate(-2 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-2-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-2</text>
+  </g>
+<line id="xGrad:-3" x1="-3" x2="-3" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-3" transform="translate(-3 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-3-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-3</text>
+  </g>
+<line id="xGrad:-4" x1="-4" x2="-4" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-4" transform="translate(-4 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-4-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-4</text>
+  </g>
+<line id="xGrad:-5" x1="-5" x2="-5" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-5" transform="translate(-5 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-5-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-5</text>
+  </g>
+<line id="xGrad:-6" x1="-6" x2="-6" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-6" transform="translate(-6 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-6-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-6</text>
+  </g>
+<line id="xGrad:-7" x1="-7" x2="-7" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-7" transform="translate(-7 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-7-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-7</text>
+  </g>
+<line id="xGrad:-8" x1="-8" x2="-8" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-8" transform="translate(-8 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-8-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-8</text>
+  </g>
+<line id="xGrad:-9" x1="-9" x2="-9" y1="-0.35" y2="0" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="x:-9" transform="translate(-9 -1.15) scale(1.0000000000000002 -1)">
+  <text id="x:-9-0" dominant-baseline="auto" text-anchor="middle" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-9</text>
+  </g>
+<g id="yAxis"><line id="yAxis-line" x1="0" x2="0" y1="-9.075" y2="9.075" stroke-width="0.09999999999999999" stroke-linecap="round" stroke="#000000"></line><polygon points="0.19134171618254484,8.613060233744356 -0.19134171618254484,8.613060233744356 0,9.075" fill="#000000" stroke="#000000" stroke-width="0.09999999999999999"></polygon>
+  </g>
+<line id="yGrad:1" x1="-0.35000000000000003" x2="0" y1="1" y2="1" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:1" transform="translate(-0.45000000000000007 0.8) scale(1.0000000000000002 -1)">
+  <text id="y:1-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">1</text>
+  </g>
+<line id="yGrad:2" x1="-0.35000000000000003" x2="0" y1="2" y2="2" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:2" transform="translate(-0.45000000000000007 1.8) scale(1.0000000000000002 -1)">
+  <text id="y:2-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">2</text>
+  </g>
+<line id="yGrad:3" x1="-0.35000000000000003" x2="0" y1="3" y2="3" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:3" transform="translate(-0.45000000000000007 2.8) scale(1.0000000000000002 -1)">
+  <text id="y:3-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">3</text>
+  </g>
+<line id="yGrad:4" x1="-0.35000000000000003" x2="0" y1="4" y2="4" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:4" transform="translate(-0.45000000000000007 3.8) scale(1.0000000000000002 -1)">
+  <text id="y:4-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">4</text>
+  </g>
+<line id="yGrad:5" x1="-0.35000000000000003" x2="0" y1="5" y2="5" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:5" transform="translate(-0.45000000000000007 4.8) scale(1.0000000000000002 -1)">
+  <text id="y:5-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">5</text>
+  </g>
+<line id="yGrad:6" x1="-0.35000000000000003" x2="0" y1="6" y2="6" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:6" transform="translate(-0.45000000000000007 5.8) scale(1.0000000000000002 -1)">
+  <text id="y:6-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">6</text>
+  </g>
+<line id="yGrad:7" x1="-0.35000000000000003" x2="0" y1="7" y2="7" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:7" transform="translate(-0.45000000000000007 6.8) scale(1.0000000000000002 -1)">
+  <text id="y:7-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">7</text>
+  </g>
+<line id="yGrad:8" x1="-0.35000000000000003" x2="0" y1="8" y2="8" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:8" transform="translate(-0.45000000000000007 7.8) scale(1.0000000000000002 -1)">
+  <text id="y:8-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">8</text>
+  </g>
+<line id="yGrad:-1" x1="-0.35000000000000003" x2="0" y1="-1" y2="-1" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-1" transform="translate(-0.45000000000000007 -1.2) scale(1.0000000000000002 -1)">
+  <text id="y:-1-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-1</text>
+  </g>
+<line id="yGrad:-2" x1="-0.35000000000000003" x2="0" y1="-2" y2="-2" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-2" transform="translate(-0.45000000000000007 -2.2) scale(1.0000000000000002 -1)">
+  <text id="y:-2-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-2</text>
+  </g>
+<line id="yGrad:-3" x1="-0.35000000000000003" x2="0" y1="-3" y2="-3" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-3" transform="translate(-0.45000000000000007 -3.2) scale(1.0000000000000002 -1)">
+  <text id="y:-3-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-3</text>
+  </g>
+<line id="yGrad:-4" x1="-0.35000000000000003" x2="0" y1="-4" y2="-4" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-4" transform="translate(-0.45000000000000007 -4.2) scale(1.0000000000000002 -1)">
+  <text id="y:-4-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-4</text>
+  </g>
+<line id="yGrad:-5" x1="-0.35000000000000003" x2="0" y1="-5" y2="-5" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-5" transform="translate(-0.45000000000000007 -5.2) scale(1.0000000000000002 -1)">
+  <text id="y:-5-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-5</text>
+  </g>
+<line id="yGrad:-6" x1="-0.35000000000000003" x2="0" y1="-6" y2="-6" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-6" transform="translate(-0.45000000000000007 -6.2) scale(1.0000000000000002 -1)">
+  <text id="y:-6-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-6</text>
+  </g>
+<line id="yGrad:-7" x1="-0.35000000000000003" x2="0" y1="-7" y2="-7" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-7" transform="translate(-0.45000000000000007 -7.2) scale(1.0000000000000002 -1)">
+  <text id="y:-7-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-7</text>
+  </g>
+<line id="yGrad:-8" x1="-0.35000000000000003" x2="0" y1="-8" y2="-8" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-8" transform="translate(-0.45000000000000007 -8.2) scale(1.0000000000000002 -1)">
+  <text id="y:-8-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-8</text>
+  </g>
+<line id="yGrad:-9" x1="-0.35000000000000003" x2="0" y1="-9" y2="-9" stroke-width="0.049999999999999996" stroke-linecap="round" stroke="#000000"></line>
+<g id="y:-9" transform="translate(-0.45000000000000007 -9.2) scale(1.0000000000000002 -1)">
+  <text id="y:-9-0" dominant-baseline="auto" text-anchor="end" font-size="0.7999999999999999" font-family="Nunito Sans" fill="black" x="0" y="0">-9</text>
+  </g>
+      </g>
+    </svg></svg>`
+
+      const simpleCutArrowSvg = `<svg viewBox="63 90.828125 326 298" width="326" height="298">
+        <rect x="63" y="90.828125" width="326" height="290" fill="none" stroke="black" stroke-width="2" />
+        <svg width="440" height="505.99999999999994" viewBox="-10 -11.575 20 23.15" x="0" y="0">
+          <g transform="scale(1 -1) translate(0 0)">      
+            <polygon points="9.538060233744357,-0.1913417161825449 9.538060233744357,0.1913417161825449 10,0" fill="#000000" stroke="#000000" stroke-width="0.1" />
+            <polygon points="0.19134171618254484,11.113060233744356 -0.19134171618254484,11.113060233744356 0,11.575" fill="#000000" stroke="#000000" stroke-width="0.1" />
+          </g>
+        </svg>
+      </svg>`;
+
       const drawLines = (page) => {
         Array(10)
           .fill(1)
@@ -130,6 +325,20 @@
         width: 231,
         x: 100,
         y: 700,
+      });
+
+      await firstPage.drawSvg(cutArrowSvg, {
+        height: 246.75,
+        width: 231,
+        x: 500,
+        y: 700,
+      });
+
+      await firstPage.drawSvg(simpleCutArrowSvg, {
+        height: 246.75,
+        width: 231,
+        x: 500,
+        y: 300,
       });
 
       const pdfBytes = await pdfDoc.save();

--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -825,12 +825,6 @@ const runnersToPage = (
   async circle(element) {
     return runnersToPage(page, options).ellipse(element);
   },
-  async polygon(element) {
-    const d = `M ${element.svgAttributes.points} Z`;
-    element.tagName = 'path';
-    element.svgAttributes['d'] = d;
-    return runnersToPage(page, options).path(element);
-  },
 });
 
 const transform = (
@@ -1145,24 +1139,6 @@ const parseAttributes = (
     svgAttributes.height = size.height;
   }
 
-  if (attributes.points) {
-    const { x: xOrigin, y: yOrigin } = newConverter.point(0, 0);
-    const params = attributes.points.match(
-      /(-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?)|(-?\.[0-9]+(e[+-]?[0-9]+)?)|(-?[0-9]+)/gi,
-    );
-    if (params) {
-      const groupedParams = groupBy<string>(params, 2);
-      svgAttributes.points = groupedParams
-        .map((pair) => {
-          const [x, y] = pair;
-          const xReal = parseFloatValue(x, inherited.width) || 0;
-          const yReal = parseFloatValue(y, innerHeight) || 0;
-          const point = newConverter.point(xReal, yReal);
-          return [point.x - xOrigin, point.y - yOrigin].join(',');
-        })
-        .join(' ');
-    }
-  }
   // We convert all the points from the path
   if (attributes.d) {
     const { x: xOrigin, y: yOrigin } = newConverter.point(0, 0);
@@ -1565,6 +1541,11 @@ const parseHTMLNode = (
       converter,
     );
   } else {
+    if (node.tagName === 'polygon') {
+      node.tagName = 'path';
+      node.attributes.d = `M${node.attributes.points}Z`; 
+      delete node.attributes.points;
+    }
     const attributes = parseAttributes(node, inherited, converter);
     const svgAttributes = {
       ...attributes.inherited,


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->

It makes polygons be properly cropped out.

## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->

Axis arrows were not being properly cropped, such arrows were polygons.

## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->

When a polygon is met, it's converted into a path, since you can make a line-based path based on a polygon's points. I've also considered adding a polygon case for `cropSvgElement`, but that'd require more effort, and probably lead to more errors down the line.

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->

By comparing drawing results. It's easy to alter point values in `simpleCutArrowSvg` to make it cross the svg's crop area. You'll find that it'll be cut in the correct horizontal/vertical line. The result isn't a perfectly-cropped image, mind you, but that's because a `path`'s cropping seems to be faulty, not because of this solution.

## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->

No.

## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->

![image](https://github.com/cantoo-scribe/pdf-lib/assets/54117007/12e4780e-8e77-41c4-afa2-cfd5ffce3b74)

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->

No.

## Anything Else?
<!-- Please share any additional notes here. -->

As mentioned, though this code should be functional, I found a problem with the cropping of a `path` itself. For a practical example: If you replace `simpleCutArrowSvg`'s `<polygon points="9.538060233744357,-0.1913417161825449 9.538060233744357,0.1913417161825449 10,0" fill="#000000" stroke="#000000" stroke-width="0.1" />` for `<path d="M7.538060233744357,-0.1913417161825449L7.538060233744357,0.1913417161825449L10,0Z" fill="#000000" stroke="#000000" stroke-width="0.1" />`, you'll notice that the result will be

![image](https://github.com/cantoo-scribe/pdf-lib/assets/54117007/267ad56c-10da-41fe-93d0-53154aa01a0f)

instead of the expected

![image](https://github.com/cantoo-scribe/pdf-lib/assets/54117007/cbff4756-1be9-4512-9201-a0dc3aee2ec6)

## Checklist
- [ ] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [ ] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [ ] My changes work for both **new** and **existing** PDF files.
- [ ] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
