### PR TITLE
Fix pdf with invalid keylen

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -133,6 +133,7 @@ export default class PDFDocument {
       ignoreEncryption = false,
       parseSpeed = ParseSpeeds.Slow,
       throwOnInvalidObject = false,
+      warnOnInvalidObjects = false,
       updateMetadata = true,
       capNumbers = false,
       password,
@@ -142,6 +143,7 @@ export default class PDFDocument {
     assertIs(ignoreEncryption, 'ignoreEncryption', ['boolean']);
     assertIs(parseSpeed, 'parseSpeed', ['number']);
     assertIs(throwOnInvalidObject, 'throwOnInvalidObject', ['boolean']);
+    assertIs(warnOnInvalidObjects, 'warnOnInvalidObjects', ['boolean']);
     assertIs(password, 'password', ['string', 'undefined']);
 
     const bytes = toUint8Array(pdf);
@@ -159,6 +161,7 @@ export default class PDFDocument {
         bytes,
         parseSpeed,
         throwOnInvalidObject,
+        warnOnInvalidObjects,
         capNumbers,
         new CipherTransformFactory(
           encryptDict,

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -25,6 +25,7 @@ export interface LoadOptions {
   ignoreEncryption?: boolean;
   parseSpeed?: ParseSpeeds | number;
   throwOnInvalidObject?: boolean;
+  warnOnInvalidObjects?: boolean;
   updateMetadata?: boolean;
   capNumbers?: boolean;
   password?: string;

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -1545,7 +1545,7 @@ class CipherTransformFactory {
       throw new Error('unsupported encryption algorithm');
     }
     this.algorithm = algorithm;
-    let keyLength = (dict.get(PDFName.of('Length')) as PDFNumber).asNumber();
+    let keyLength = (dict.get(PDFName.of('Length')) as PDFNumber | undefined)?.asNumber();
     if (!keyLength) {
       // Spec asks to rely on encryption dictionary's Length entry, however
       // some PDFs don't have it. Trying to recover.
@@ -1574,8 +1574,8 @@ class CipherTransformFactory {
         }
       }
     }
-    if (!Number.isInteger(keyLength) || keyLength < 40 || keyLength % 8 !== 0) {
-      throw new Error('invalid key length');
+    if (keyLength === undefined || !Number.isInteger(keyLength) || keyLength < 40 || keyLength % 8 !== 0) {
+      throw new Error(`invalid key length: ${keyLength}`);
     }
 
     const oPdfStr = (dict.get(PDFName.of('O')) as PDFString).asBytes();

--- a/src/core/parser/PDFParser.ts
+++ b/src/core/parser/PDFParser.ts
@@ -30,6 +30,7 @@ class PDFParser extends PDFObjectParser {
     pdfBytes: Uint8Array,
     objectsPerTick?: number,
     throwOnInvalidObject?: boolean,
+    warnOnInvalidObjects?: boolean,
     capNumbers?: boolean,
     cryptoFactory?: CipherTransformFactory,
   ) =>
@@ -37,12 +38,14 @@ class PDFParser extends PDFObjectParser {
       pdfBytes,
       objectsPerTick,
       throwOnInvalidObject,
+      warnOnInvalidObjects,
       capNumbers,
       cryptoFactory,
     );
 
   private readonly objectsPerTick: number;
   private readonly throwOnInvalidObject: boolean;
+  private readonly warnOnInvalidObjects: boolean;
   private alreadyParsed = false;
   private parsedObjects = 0;
 
@@ -50,6 +53,7 @@ class PDFParser extends PDFObjectParser {
     pdfBytes: Uint8Array,
     objectsPerTick = Infinity,
     throwOnInvalidObject = false,
+    warnOnInvalidObjects = false,
     capNumbers = false,
     cryptoFactory?: CipherTransformFactory,
   ) {
@@ -61,6 +65,7 @@ class PDFParser extends PDFObjectParser {
     );
     this.objectsPerTick = objectsPerTick;
     this.throwOnInvalidObject = throwOnInvalidObject;
+    this.warnOnInvalidObjects = warnOnInvalidObjects;
     this.context.isDecrypted = !!cryptoFactory?.encryptionKey
   }
 
@@ -197,11 +202,11 @@ class PDFParser extends PDFObjectParser {
 
     const msg = `Trying to parse invalid object: ${JSON.stringify(startPos)})`;
     if (this.throwOnInvalidObject) throw new Error(msg);
-    console.warn(msg);
+    this.warnOnInvalidObjects && console.warn(msg);
 
     const ref = this.parseIndirectObjectHeader();
 
-    console.warn(`Invalid object ref: ${ref}`);
+    this.warnOnInvalidObjects && console.warn(`Invalid object ref: ${ref}`);
 
     this.skipWhitespaceAndComments();
     const start = this.bytes.offset();


### PR DESCRIPTION
Fix the special case when `keyLength` is `undefined` (https://github.com/cantoo-scribe/pdf-lib/issues/44)

Add the option to suppress warnings during objects parsing (https://github.com/cantoo-scribe/pdf-lib/issues/40)


