### PR TITLE
try to speed up copyPages

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -758,14 +758,11 @@ export default class PDFDocument {
     await srcDoc.flush();
     const copier = PDFObjectCopier.for(srcDoc.context, this.context);
     const srcPages = srcDoc.getPages();
-    const copiedPages: PDFPage[] = new Array(indices.length);
-    for (let idx = 0, len = indices.length; idx < len; idx++) {
-      const srcPage = srcPages[indices[idx]];
-      const copiedPage = copier.copy(srcPage.node);
-      const ref = this.context.register(copiedPage);
-      copiedPages[idx] = PDFPage.of(copiedPage, ref, this);
-    }
-    return copiedPages;
+    const copiedPages = indices
+      .map((i) => srcPages[i])
+      .map((page) => copier.copy(page.node))
+      .map((copy) => PDFPage.of(copy, this.context.register(copy), this));
+    return await Promise.all(copiedPages);
   }
 
   /**


### PR DESCRIPTION
## What?
Change copyPages to use promises because merging PDFs is slow

## Why?
merging PDFs is slow

## How?
using promises

## Testing?
I tested it in my own project and the page ordering seem to stay the same, I also ran the tests.

## New Dependencies?
no

## Screenshots
<img width="605" alt="Screenshot 2024-02-22 at 3 47 47 AM" src="https://github.com/cantoo-scribe/pdf-lib/assets/18414941/7be56d15-814c-4fde-95da-c2bedb7c4e55">
