### PR TITLE
Fix issue that was causing Adobe Acrobat to throw an error

### DIFF
--- a/src/core/writers/PDFStreamWriter.ts
+++ b/src/core/writers/PDFStreamWriter.ts
@@ -6,6 +6,9 @@ import PDFNumber from '../objects/PDFNumber';
 import PDFObject from '../objects/PDFObject';
 import PDFRef from '../objects/PDFRef';
 import PDFStream from '../objects/PDFStream';
+import PDFCatalog from '../structures/PDFCatalog';
+import PDFPageTree from '../structures/PDFPageTree';
+import PDFPageLeaf from '../structures/PDFPageLeaf';
 import PDFContext from '../PDFContext';
 import PDFCrossRefStream from '../structures/PDFCrossRefStream';
 import PDFObjectStream from '../structures/PDFObjectStream';
@@ -68,6 +71,9 @@ class PDFStreamWriter extends PDFWriter {
         ref === this.context.trailerInfo.Encrypt ||
         object instanceof PDFStream ||
         object instanceof PDFInvalidObject ||
+        object instanceof PDFCatalog ||
+        object instanceof PDFPageTree ||
+        object instanceof PDFPageLeaf ||
         ref.generationNumber !== 0;
 
       if (shouldNotCompress) {


### PR DESCRIPTION
See comments in #54 to see the error message.

This became noticeable when opening encrypted files.

Thanks to @RippleRurigaki for finding the problem.