### PR TITLE
Fix `api/operations::drawRectangle` border radius

### DIFF
--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -245,7 +245,7 @@ export const drawRectangle = (options: {
 
   // Ensure rx and ry are within bounds
   const rx = Math.max(0, Math.min(options.rx || 0, w / 2));
-  const ry = Math.max(0, Math.min(options.ry || 0, h / 2));
+  const ry = Math.min(0, Math.max(options.ry || 0, h / 2));
 
   // Generate the SVG path
   const d =

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -245,7 +245,7 @@ export const drawRectangle = (options: {
 
   // Ensure rx and ry are within bounds
   const rx = Math.max(0, Math.min(options.rx || 0, w / 2));
-  const ry = Math.min(0, Math.max(options.ry || 0, h / 2));
+  const ry = Math.min(0, Math.max(-(options.ry || 0), h / 2));
 
   // Generate the SVG path
   const d =


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
This PR addresses an issue caused by a recent change of line 242 from
```ts
const h = (typeof height === 'number' ? height : height.asNumber());
```
to
```ts
const h = -(typeof height === 'number' ? height : height.asNumber());
```
without also properly negating subsequent computations which utilize `h`.

## Why?
As is, `ry` is always clamped to zero, negating any border radius applied. Additionally, as is, `ry` as provided would have to be negative, which is unintuitive.

## How?
This PR reverses the bounds of the clamp to let `ry = -options.ry` instead of `ry = options.ry` subject to `(-options.height)/2 <= ry <= 0` instead of `0 <= ry <= (-options.height)/2`.

## Testing?
This change was tested on a local copy of this repository.


## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->
No

## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->
N/A

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->
Yes

## Anything Else?
<!-- Please share any additional notes here. -->
N/A

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [x] I added/updated unit tests for my changes.
- [x] I added/updated integration tests for my changes.
- [x] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [x] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [x] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
