### PR TITLE
Fully support language in document

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -393,6 +393,22 @@ export default class PDFDocument {
   }
 
   /**
+   * Get this document's language metadata. The language appears in the
+   * "Document Properties" section of most PDF readers. For example:
+   * ```js
+   * const language = pdfDoc.getLanguage()
+   * ```
+   * @returns A string containing the RFC 3066 _Language-Tag_ of this document,
+   *          if it has one.
+   */
+  getLanguage(): string | undefined {
+    const language = this.catalog.get(PDFName.of('Lang'));
+    if (!language) return undefined;
+    assertIsLiteralOrHexString(language);
+    return language.decodeText();
+  }
+
+  /**
    * Get this document's creation date metadata. The creation date appears in
    * the "Document Properties" section of most PDF readers. For example:
    * ```js
@@ -805,6 +821,9 @@ export default class PDFDocument {
     }
     if (this.getCreator() !== undefined) {
       pdfCopy.setCreator(this.getCreator()!);
+    }
+    if (this.getLanguage() !== undefined) {
+      pdfCopy.setLanguage(this.getLanguage()!);
     }
     if (this.getModificationDate() !== undefined) {
       pdfCopy.setModificationDate(this.getModificationDate()!);

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -166,16 +166,18 @@ describe(`PDFDocument`, () => {
   describe(`setLanguage() method`, () => {
     it(`sets the language of the document`, async () => {
       const pdfDoc = await PDFDocument.create();
-      expect(pdfDoc.catalog.get(PDFName.of('Lang'))).toBeUndefined();
+      expect(pdfDoc.getLanguage()).toBeUndefined();
 
       pdfDoc.setLanguage('fr-FR');
-      expect(String(pdfDoc.catalog.get(PDFName.of('Lang')))).toBe('(fr-FR)');
+      expect(pdfDoc.getLanguage()).toBe(
+        'fr-FR',
+      );
 
       pdfDoc.setLanguage('en');
-      expect(String(pdfDoc.catalog.get(PDFName.of('Lang')))).toBe('(en)');
+      expect(pdfDoc.getLanguage()).toBe('en');
 
       pdfDoc.setLanguage('');
-      expect(String(pdfDoc.catalog.get(PDFName.of('Lang')))).toBe('()');
+      expect(pdfDoc.getLanguage()).toBe('');
     });
   });
 


### PR DESCRIPTION
## What?

Currently there is only a function for setting the language but with a wrong key ("Lang" instead of "Language").

This PR changes the key and adds a getter for the language.

## Why?
The current implementation is incomplete and not compatible with Adobe Acrobat.

## How?
It works analog to other data in document info.

## Testing?
Add the language information and checked the existence with exiftool.

## New Dependencies?

## Screenshots

## Suggested Reading?

## Anything Else?

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [x] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [x] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
