### PR TITLE
Fix drawReactangle to ivert y-axis by using transformation instead of…

### DIFF
--- a/apps/web/test30.html
+++ b/apps/web/test30.html
@@ -72,6 +72,28 @@
         });
       }
 
+      const drawGrid = (page) => {
+        const n = 100
+        Array(parseInt(page.getHeight() / n))
+          .fill(1)
+          .map((v, i) => {
+            page.drawLine({
+              start: { x: 0, y: i * n },
+              end: { x: page.getWidth(), y: i * n },
+            });
+          });
+        Array(parseInt(page.getWidth() / n))
+          .fill(1)
+          .map((v, i) => {
+            page.drawLine({
+              start: { x: i * n, y: 0 },
+              end: { x: i * n, y: page.getHeight() },
+            });
+          });
+      };
+
+      drawGrid(page)
+
       // Draw a filled rectangle with sharp corners
       drawRectangle(50, 500, 100, 50, {
         color: rgb(1, 0, 0), // red
@@ -107,6 +129,12 @@
       });
 
       page.drawSvg(svg, { x: 200, y: 300, width: 100, height: 50 });
+
+      drawRectangle(300, 300, 100, 50, {
+        color: rgb(0.5, 0.5, 0),
+        rx: 25,
+        ry: 25,
+      });
 
       const pdfBytes = await pdfDoc.save();
       renderInIframe(pdfBytes);

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -239,10 +239,10 @@ export const drawRectangle = (options: {
 }) => {
   const { width, height, xSkew, ySkew, rotate, matrix } = options;
   const w = typeof width === 'number' ? width : width.asNumber();
-  const h = -(typeof height === 'number' ? height : height.asNumber());
+  const h = typeof height === 'number' ? height : height.asNumber();
   const x = typeof options.x === 'number' ? options.x : options.x.asNumber();
   const y = typeof options.y === 'number' ? options.y : options.y.asNumber();
-
+  
   // Ensure rx and ry are within bounds
   const rx = Math.max(0, Math.min(options.rx || 0, w / 2));
   const ry = Math.max(0, Math.min(options.ry || 0, h / 2));
@@ -264,14 +264,14 @@ export const drawRectangle = (options: {
         ].join(' ')
       : `M 0,0 H ${w} V ${h} H 0 Z`;
 
-  // Transformation to apply rotation and skew
   // the drawRectangle applies the rotation around its anchor point (bottom-left), it means that the translation should be applied before the rotation
   // invert the y parameter because transformationToMatrix expects parameters from an svg space. The same is valid for rotate and ySkew
   let fullMatrix = combineMatrix(
     matrix || identityMatrix,
     transformationToMatrix('translate', [x, -y]),
   );
-
+      
+  // Transformation to apply rotation and skew
   if (rotate) {
     fullMatrix = combineMatrix(
       fullMatrix,
@@ -290,6 +290,13 @@ export const drawRectangle = (options: {
       transformationToMatrix('skewY', [-toDegrees(ySkew)]),
     );
   }
+
+  // move the rectangle upward so that the (x, y) coord is bottom-left 
+  fullMatrix = combineMatrix(
+    fullMatrix,
+    transformationToMatrix('translateY', [-h]),
+  );
+
   return drawSvgPath(d, {
     ...options,
     x: 0,

--- a/src/api/svg.ts
+++ b/src/api/svg.ts
@@ -390,7 +390,7 @@ const runnersToPage = (
       x: 0,
       y: 0,
       width: element.svgAttributes.width,
-      height: element.svgAttributes.height * -1,
+      height: element.svgAttributes.height,
       rx: element.svgAttributes.rx,
       ry: element.svgAttributes.ry,
       borderColor: element.svgAttributes.stroke,
@@ -399,7 +399,7 @@ const runnersToPage = (
       borderLineCap: element.svgAttributes.strokeLineCap,
       color: element.svgAttributes.fill,
       opacity: element.svgAttributes.fillOpacity,
-      matrix: element.svgAttributes.matrix,
+      matrix: combineTransformation(element.svgAttributes.matrix, 'translateY', [element.svgAttributes.height]),
       clipSpaces: element.svgAttributes.clipSpaces,
       blendMode: options.blendMode,
     });


### PR DESCRIPTION
… negative height

<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->
It fixes the issue reported by #78
## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->
It fixes the border radius support on `drawRectangle`
## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->
I checked all the HTML test files.

## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->
no
## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->
no
## Anything Else?
<!-- Please share any additional notes here. -->

