### PR TITLE
[Feature] Add. PdfDoc.saveToTargetPath() for Writing PDF Directly to File Path

### DIFF
--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -21,6 +21,11 @@ export interface Base64SaveOptions extends SaveOptions {
   dataUri?: boolean;
 }
 
+export interface FileSaveOptions extends SaveOptions {
+  outputPath: string;
+  forceWrite?: boolean;
+}
+
 export interface LoadOptions {
   ignoreEncryption?: boolean;
   parseSpeed?: ParseSpeeds | number;

--- a/src/core/document/PDFHeader.ts
+++ b/src/core/document/PDFHeader.ts
@@ -1,5 +1,10 @@
+import { Writable } from 'stream';
 import CharCodes from '../syntax/CharCodes';
-import { charFromCode, copyStringIntoBuffer } from '../../utils';
+import {
+  charFromCode,
+  convertStringToUnicodeArray,
+  copyStringIntoBuffer,
+} from '../../utils';
 
 class PDFHeader {
   static forVersion = (major: number, minor: number) =>
@@ -47,6 +52,23 @@ class PDFHeader {
     buffer[offset++] = 129;
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(
+      Buffer.from([
+        CharCodes.Percent,
+        CharCodes.P,
+        CharCodes.D,
+        CharCodes.F,
+        CharCodes.Dash,
+      ]),
+    );
+    stream.write(convertStringToUnicodeArray(this.major));
+    stream.write(Buffer.from([CharCodes.Period]));
+    stream.write(convertStringToUnicodeArray(this.minor));
+    stream.write(Buffer.from([CharCodes.Newline]));
+    stream.write(Buffer.from([CharCodes.Percent, 129, 129, 129, 129]));
   }
 }
 

--- a/src/core/document/PDFTrailer.ts
+++ b/src/core/document/PDFTrailer.ts
@@ -1,5 +1,6 @@
 import CharCodes from '../syntax/CharCodes';
-import { copyStringIntoBuffer } from '../../utils';
+import { convertStringToUnicodeArray, copyStringIntoBuffer } from '../../utils';
+import { Writable } from 'stream';
 
 class PDFTrailer {
   static forLastCrossRefSectionOffset = (offset: number) =>
@@ -43,6 +44,36 @@ class PDFTrailer {
     buffer[offset++] = CharCodes.F;
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(
+      Buffer.from([
+        CharCodes.s,
+        CharCodes.t,
+        CharCodes.a,
+        CharCodes.r,
+        CharCodes.t,
+        CharCodes.x,
+        CharCodes.r,
+        CharCodes.e,
+        CharCodes.f,
+        CharCodes.Newline,
+      ]),
+    );
+
+    stream.write(convertStringToUnicodeArray(this.lastXRefOffset));
+
+    stream.write(
+      Buffer.from([
+        CharCodes.Newline,
+        CharCodes.Percent,
+        CharCodes.Percent,
+        CharCodes.E,
+        CharCodes.O,
+        CharCodes.F,
+      ]),
+    );
   }
 }
 

--- a/src/core/document/PDFTrailerDict.ts
+++ b/src/core/document/PDFTrailerDict.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'stream';
 import PDFDict from '../objects/PDFDict';
 import CharCodes from '../syntax/CharCodes';
 
@@ -33,6 +34,23 @@ class PDFTrailerDict {
     offset += this.dict.copyBytesInto(buffer, offset);
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(
+      Buffer.from([
+        CharCodes.t,
+        CharCodes.r,
+        CharCodes.a,
+        CharCodes.i,
+        CharCodes.l,
+        CharCodes.e,
+        CharCodes.r,
+        CharCodes.Newline,
+      ]),
+    );
+
+    this.dict.writeBytesInto(stream);
   }
 }
 

--- a/src/core/objects/PDFArray.ts
+++ b/src/core/objects/PDFArray.ts
@@ -12,6 +12,7 @@ import PDFContext from '../PDFContext';
 import CharCodes from '../syntax/CharCodes';
 import { PDFArrayIsNotRectangleError } from '../errors';
 import PDFRawStream from './PDFRawStream';
+import { Writable } from 'stream';
 
 class PDFArray extends PDFObject {
   static withContext = (context: PDFContext) => new PDFArray(context);
@@ -169,6 +170,17 @@ class PDFArray extends PDFObject {
     buffer[offset++] = CharCodes.RightSquareBracket;
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(Buffer.from([CharCodes.LeftSquareBracket, CharCodes.Space]));
+
+    this.array.forEach((obj) => {
+      obj.writeBytesInto(stream);
+      stream.write(Buffer.from([CharCodes.Space]));
+    });
+
+    stream.write(Buffer.from([CharCodes.RightSquareBracket]));
   }
 
   scalePDFNumbers(x: number, y: number): void {

--- a/src/core/objects/PDFBool.ts
+++ b/src/core/objects/PDFBool.ts
@@ -1,6 +1,7 @@
 import { PrivateConstructorError } from '../errors';
 import PDFObject from './PDFObject';
 import CharCodes from '../syntax/CharCodes';
+import { Writable } from 'stream';
 
 const ENFORCER = {};
 
@@ -47,6 +48,22 @@ class PDFBool extends PDFObject {
       buffer[offset++] = CharCodes.e;
       return 5;
     }
+  }
+
+  writeBytesInto(stream: Writable): void {
+    this.value
+      ? stream.write(
+          Buffer.from([CharCodes.t, CharCodes.r, CharCodes.u, CharCodes.e]),
+        )
+      : stream.write(
+          Buffer.from([
+            CharCodes.f,
+            CharCodes.a,
+            CharCodes.l,
+            CharCodes.s,
+            CharCodes.e,
+          ]),
+        );
   }
 }
 

--- a/src/core/objects/PDFDict.ts
+++ b/src/core/objects/PDFDict.ts
@@ -1,3 +1,6 @@
+import { Writable } from 'stream';
+import PDFContext from '../PDFContext';
+import CharCodes from '../syntax/CharCodes';
 import PDFArray from './PDFArray';
 import PDFBool from './PDFBool';
 import PDFHexString from './PDFHexString';
@@ -8,8 +11,6 @@ import PDFObject from './PDFObject';
 import PDFRef from './PDFRef';
 import PDFStream from './PDFStream';
 import PDFString from './PDFString';
-import PDFContext from '../PDFContext';
-import CharCodes from '../syntax/CharCodes';
 
 export type DictMap = Map<PDFName, PDFObject>;
 
@@ -222,6 +223,22 @@ class PDFDict extends PDFObject {
     buffer[offset++] = CharCodes.GreaterThan;
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(
+      Buffer.from([CharCodes.LessThan, CharCodes.LessThan, CharCodes.Newline]),
+    );
+
+    this.entries().forEach((ent) => {
+      const [key, value] = ent;
+      key.writeBytesInto(stream);
+      stream.write(Buffer.from([CharCodes.Space]));
+      value.writeBytesInto(stream);
+      stream.write(Buffer.from([CharCodes.Newline]));
+    });
+
+    stream.write(Buffer.from([CharCodes.GreaterThan, CharCodes.GreaterThan]));
   }
 }
 

--- a/src/core/objects/PDFHexString.ts
+++ b/src/core/objects/PDFHexString.ts
@@ -9,8 +9,10 @@ import {
   parseDate,
   hasUtf16BOM,
   byteArrayToHexString,
+  convertStringToUnicodeArray,
 } from '../../utils';
 import { InvalidPDFDateStringError } from '../errors';
+import { Writable } from 'stream';
 
 class PDFHexString extends PDFObject {
   static of = (value: string) => new PDFHexString(value);
@@ -92,6 +94,12 @@ class PDFHexString extends PDFObject {
     offset += copyStringIntoBuffer(this.value, buffer, offset);
     buffer[offset++] = CharCodes.GreaterThan;
     return this.value.length + 2;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(Buffer.from([CharCodes.LessThan]));
+    stream.write(convertStringToUnicodeArray(this.value));
+    stream.write(Buffer.from([CharCodes.GreaterThan]));
   }
 }
 

--- a/src/core/objects/PDFInvalidObject.ts
+++ b/src/core/objects/PDFInvalidObject.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'stream';
 import PDFObject from './PDFObject';
 
 class PDFInvalidObject extends PDFObject {
@@ -28,6 +29,10 @@ class PDFInvalidObject extends PDFObject {
       buffer[offset++] = this.data[idx];
     }
     return length;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(this.data);
   }
 }
 

--- a/src/core/objects/PDFName.ts
+++ b/src/core/objects/PDFName.ts
@@ -4,10 +4,12 @@ import CharCodes from '../syntax/CharCodes';
 import { IsIrregular } from '../syntax/Irregular';
 import {
   charFromHexCode,
+  convertStringToUnicodeArray,
   copyStringIntoBuffer,
   toCharCode,
   toHexString,
 } from '../../utils';
+import { Writable } from 'stream';
 
 const decodeName = (name: string) =>
   name.replace(/#([\dABCDEF]{2})/g, (_, hex) => charFromHexCode(hex));
@@ -153,6 +155,10 @@ class PDFName extends PDFObject {
   copyBytesInto(buffer: Uint8Array, offset: number): number {
     offset += copyStringIntoBuffer(this.encodedName, buffer, offset);
     return this.encodedName.length;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(convertStringToUnicodeArray(this.encodedName));
   }
 }
 

--- a/src/core/objects/PDFNull.ts
+++ b/src/core/objects/PDFNull.ts
@@ -1,5 +1,6 @@
 import PDFObject from './PDFObject';
 import CharCodes from '../syntax/CharCodes';
+import { Writable } from 'stream';
 
 class PDFNull extends PDFObject {
   asNull(): null {
@@ -24,6 +25,12 @@ class PDFNull extends PDFObject {
     buffer[offset++] = CharCodes.l;
     buffer[offset++] = CharCodes.l;
     return 4;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(
+      Buffer.from([CharCodes.n, CharCodes.u, CharCodes.l, CharCodes.l]),
+    );
   }
 }
 

--- a/src/core/objects/PDFNumber.ts
+++ b/src/core/objects/PDFNumber.ts
@@ -1,4 +1,9 @@
-import { copyStringIntoBuffer, numberToString } from '../../utils/index';
+import { Writable } from 'stream';
+import {
+  convertStringToUnicodeArray,
+  copyStringIntoBuffer,
+  numberToString,
+} from '../../utils/index';
 
 import PDFObject from './PDFObject';
 
@@ -38,6 +43,10 @@ class PDFNumber extends PDFObject {
   copyBytesInto(buffer: Uint8Array, offset: number): number {
     offset += copyStringIntoBuffer(this.stringValue, buffer, offset);
     return this.stringValue.length;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(convertStringToUnicodeArray(this.stringValue));
   }
 }
 

--- a/src/core/objects/PDFObject.ts
+++ b/src/core/objects/PDFObject.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'stream';
 import { MethodNotImplementedError } from '../errors';
 import PDFContext from '../PDFContext';
 
@@ -16,6 +17,13 @@ class PDFObject {
 
   copyBytesInto(_buffer: Uint8Array, _offset: number): number {
     throw new MethodNotImplementedError(this.constructor.name, 'copyBytesInto');
+  }
+
+  writeBytesInto(_stream: Writable): void {
+    throw new MethodNotImplementedError(
+      this.constructor.name,
+      'writeBytesInto',
+    );
   }
 }
 

--- a/src/core/objects/PDFRef.ts
+++ b/src/core/objects/PDFRef.ts
@@ -1,6 +1,7 @@
 import { PrivateConstructorError } from '../errors';
 import PDFObject from '../objects/PDFObject';
-import { copyStringIntoBuffer } from '../../utils';
+import { convertStringToUnicodeArray, copyStringIntoBuffer } from '../../utils';
+import { Writable } from 'stream';
 
 const ENFORCER = {};
 const pool = new Map<string, PDFRef>();
@@ -49,6 +50,10 @@ class PDFRef extends PDFObject {
   copyBytesInto(buffer: Uint8Array, offset: number): number {
     offset += copyStringIntoBuffer(this.tag, buffer, offset);
     return this.tag.length;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(convertStringToUnicodeArray(this.tag));
   }
 }
 

--- a/src/core/objects/PDFStream.ts
+++ b/src/core/objects/PDFStream.ts
@@ -5,6 +5,7 @@ import PDFNumber from './PDFNumber';
 import PDFObject from './PDFObject';
 import PDFContext from '../PDFContext';
 import CharCodes from '../syntax/CharCodes';
+import { Writable } from 'stream';
 
 class PDFStream extends PDFObject {
   readonly dict: PDFDict;
@@ -94,6 +95,44 @@ class PDFStream extends PDFObject {
     buffer[offset++] = CharCodes.m;
 
     return offset - initialOffset;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    this.updateDict();
+
+    this.dict.writeBytesInto(stream);
+
+    stream.write(
+      Buffer.from([
+        CharCodes.Newline,
+        CharCodes.s,
+        CharCodes.t,
+        CharCodes.r,
+        CharCodes.e,
+        CharCodes.a,
+        CharCodes.m,
+        CharCodes.Newline,
+      ]),
+    );
+
+    this.getContents().forEach((content) =>
+      stream.write(Buffer.from([content])),
+    );
+
+    stream.write(
+      Buffer.from([
+        CharCodes.Newline,
+        CharCodes.e,
+        CharCodes.n,
+        CharCodes.d,
+        CharCodes.s,
+        CharCodes.t,
+        CharCodes.r,
+        CharCodes.e,
+        CharCodes.a,
+        CharCodes.m,
+      ]),
+    );
   }
 }
 

--- a/src/core/objects/PDFString.ts
+++ b/src/core/objects/PDFString.ts
@@ -8,8 +8,10 @@ import {
   toCharCode,
   parseDate,
   hasUtf16BOM,
+  convertStringToUnicodeArray,
 } from '../../utils';
 import { InvalidPDFDateStringError } from '../errors';
+import { Writable } from 'stream';
 
 class PDFString extends PDFObject {
   // The PDF spec allows newlines and parens to appear directly within a literal
@@ -112,6 +114,12 @@ class PDFString extends PDFObject {
     offset += copyStringIntoBuffer(this.value, buffer, offset);
     buffer[offset++] = CharCodes.RightParen;
     return this.value.length + 2;
+  }
+
+  writeBytesInto(stream: Writable): void {
+    stream.write(Buffer.from([CharCodes.LeftParen]));
+    stream.write(convertStringToUnicodeArray(this.value));
+    stream.write(Buffer.from([CharCodes.RightParen]));
   }
 }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -37,6 +37,10 @@ export const copyStringIntoBuffer = (
   return length;
 };
 
+export const convertStringToUnicodeArray = (str: string): Buffer => {
+  return Buffer.from(str.split('').map((char) => char.charCodeAt(0)));
+};
+
 export const addRandomSuffix = (prefix: string, suffixLength = 4) =>
   `${prefix}-${Math.floor(Math.random() * 10 ** suffixLength)}`;
 


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->

Currentiy there is only way to save an modified PDF File(`PDFDocument.save()`)  which is creates a entire Copy of PDF size buffer

this PR add a new feature(`PDFDocument.saveToTargetPath()`) totally same functionality with `PDFDocument.save()` but reduces memory usage by writing PDF data directly to specific directory path (`without copying Unit8Array`)

## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->

I created this feature to address high memory usage when working in serverless environments (e.g., AWS Lambda). When processing large PDFs (e.g., 1GB), the current implementation requires at least 2GB of memory, resulting in substantial resource costs.

This PR reduces memory requirements, which is especially important in memory-constrained environments.

For more details, please refer to the related issue I created:

- please consider at below issue (i craeted that issue)
- https://github.com/cantoo-scribe/pdf-lib/issues/71

## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->

- `PDFDocument.save()`: Creates a Uint8Array for the entire size of the modified PDF file and writes this array.
- `PDFDocument.saveToTargetPath()`: Writes the modified PDF file directly to a specified path using a Writable stream, avoiding the creation of a large Uint8Array.

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->

- Verifying the input(`outputPath`) options is valid.
- Ensuring that the results from `PDFDocument.save()` and `PDFDocument.saveToTargetPath()` are identical.


## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->
No Additional Dependency


## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->

Yes

## Anything Else?
<!-- Please share any additional notes here. -->
Nothing!

## Checklist
- [ ] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [ ] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [ ] My changes work for both **new** and **existing** PDF files.
- [ ] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
