### PR TITLE
Add widthOfText function to PDFPage

### DIFF
--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -930,6 +930,31 @@ export default class PDFPage {
   }
 
   /**
+   *
+   * Calulates the width of a given text string at the current font size.
+   *
+   * @param text
+   * @param options
+   * @returns
+   */
+  widthOfText(text: string, options: PDFPageDrawTextOptions = {}): number {
+    assertIs(text, 'text', ['string']);
+    assertOrUndefined(options.font, 'options.font', [[PDFFont, 'PDFFont']]);
+    assertOrUndefined(options.size, 'options.size', ['number']);
+
+    const { oldFont, newFont } = this.setOrEmbedFont(options.font);
+    const fontSize = options.size || this.fontSize;
+
+    const textWidth = (t: string) => newFont.widthOfTextAtSize(t, fontSize);
+
+    if (options.font) {
+      if (oldFont) this.setFont(oldFont);
+      else this.resetFont();
+    }
+    return textWidth;
+  }
+
+  /**
    * Draw one or more lines of text on this page. For example:
    * ```js
    * import { StandardFonts, rgb } from 'pdf-lib'


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
Helper function to calculate the width of some text so I can tweak the font size slightly to get the text to fit. 

## Why?
I am re-creating a document and I don't have access to the exact some fonts so I need to tweak the font size slightly to get the same layout.

## How?
It's essentially the drawText function (just without the drawing).

## Testing?
It's just a few lines of code from drawText and we've been using in production for a year or two, just trying to cleanup my build scripts and contribute the code to a upstream fork that will be maintained.


## New Dependencies?
None

## Screenshots
N/A

## Suggested Reading?
No

## Anything Else?
None

## Checklist
- [ ‭✓] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [ ‭✓] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ‭✓] I added/updated doc comments for any new/modified public APIs.
- [ ‭✓] My changes work for both **new** and **existing** PDF files.
- [ ‭✓] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
