### PR TITLE
Fix incorrect construction of dataView from Uint8Array in JpegEmbedder

### DIFF
--- a/src/core/embedders/JpegEmbedder.ts
+++ b/src/core/embedders/JpegEmbedder.ts
@@ -29,7 +29,11 @@ const ChannelToColorSpace: { [idx: number]: ColorSpace | undefined } = {
  */
 class JpegEmbedder {
   static async for(imageData: Uint8Array) {
-    const dataView = new DataView(imageData.buffer);
+    const dataView = new DataView(
+      imageData.buffer,
+      imageData.byteOffset,
+      imageData.byteLength,
+    );
 
     const soi = dataView.getUint16(0);
     if (soi !== 0xffd8) throw new Error('SOI not found in JPEG');


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
The PR adds the byteOffset and byteLength arguments to the `new DataView(imageData.buffer)` call in `JpegEmbedder.for`

## Why?
Because when the imageData: Uint8Array has its own byteOffset,byteLength it throws `new Error('SOI not found in JPEG')`

## How?
```
const dataView = new DataView(
  imageData.buffer,
  imageData.byteOffset,
  imageData.byteLength,
);
```

## Testing?
I ran
- yarn test
- yarn apps:node
- yarn apps:web

## New Dependencies?
No

## Screenshots
No

## Suggested Reading?
No

## Anything Else?

on windows, to make `yarn build` succeed I had to change:
"build:downlevel-dts": "rimraf ts3.4 && yarn downlevel-dts . ts3.4 && rimraf ts3.4/scratchpad",
to
"build:downlevel-dts": "rimraf ts3.4 && downlevel-dts . ts3.4 && rimraf ts3.4/scratchpad",

I ran `yarn lint:prettier` 
but `yarn lint:eslint` took forever and eslint.config.js seems misconfigured



## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [~] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests)
- [~] I tested my changes in Node, Deno, and the browser.
- [~] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
