### PR TITLE
パスワードありPDF表示空白不具合対応（暫定版）

### DIFF
--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -141,16 +141,18 @@ class CustomFontEmbedder {
   protected async embedCIDFontDict(context: PDFContext): Promise<PDFRef> {
     const fontDescriptorRef = await this.embedFontDescriptor(context);
 
+    const cidSystemInfo = context.obj({
+      Registry: PDFString.of('Adobe'),
+      Ordering: PDFString.of('Identity'),
+      Supplement: 0,
+    });
+
     const cidFontDict = context.obj({
       Type: 'Font',
       Subtype: this.isCFF() ? 'CIDFontType0' : 'CIDFontType2',
       CIDToGIDMap: 'Identity',
       BaseFont: this.baseFontName,
-      CIDSystemInfo: {
-        Registry: PDFString.of('Adobe'),
-        Ordering: PDFString.of('Identity'),
-        Supplement: 0,
-      },
+      CIDSystemInfo: cidSystemInfo,
       FontDescriptor: fontDescriptorRef,
       W: this.computeWidths(),
     });


### PR DESCRIPTION
@cantoo/pdf-libにおいて、パスワードありPDFを元に新規PDFを作成すると文字部分が表示されなくなる。

文字自体はあるが、フォントオブジェクトが破損してしまう事が原因である。

暫定版としてそちらを対応する。