### PR TITLE
pdfs with flattened forms can't be printed in Adobe Reader or Acrobat 

### DIFF
--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -589,12 +589,14 @@ export default class PDFForm {
     for (let i = 0, len = widgets.length; i < len; i++) {
       try {
         const widget = widgets[i];
-        const widgetRef = this.findWidgetAppearanceRef(field, widget);
+        const widgetRef = this.doc.context.getObjectRef(widget.dict);
 
         const page = this.findWidgetPage(widget);
         pages.add(page);
 
-        page.node.removeAnnot(widgetRef);
+        if (widgetRef !== undefined) {
+          page.node.removeAnnot(widgetRef);
+        }
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
Gets correct widget ref from the document to remove the corresponding annotation ref from the page

## Why?
Trying to fix this issue: https://github.com/Hopding/pdf-lib/issues/1267
Original discussion: https://github.com/Hopding/pdf-lib/pull/1268

## How?
Gets the ref using doc.context.getObjectRef instead of findWidgetAppearanceRef (which seems to get the wrong ref?)

## Testing?
Ran the unit tests

## New Dependencies?
N/A

## Screenshots
N/A

## Suggested Reading?
N/A

## Anything Else?
N/A

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [x] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [x] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
