### PR TITLE
working with xfa forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Install with: `npm install @cantoo/pdf-lib`
   - [Work with XFA Forms](#work-with-xfa-forms)
   - [Extract XFA JavaScript](#extract-xfa-javascript)
   - [Modify XFA JavaScript](#modify-xfa-javascript)
+  - [Extract Document JavaScript](#extract-document-javascript)
   - [Copy Pages](#copy-pages)
   - [Embed PNG and JPEG Images](#embed-png-and-jpeg-images)
   - [Embed PDF Pages](#embed-pdf-pages)
@@ -110,6 +111,7 @@ Install with: `npm install @cantoo/pdf-lib`
 - Preserve XFA forms
 - Extract XFA JavaScript
 - Modify XFA JavaScript
+- Extract document-level JavaScript
 - Add Pages
 - Insert Pages
 - Remove Pages
@@ -757,13 +759,11 @@ const pdfDoc = await PDFDocument.load(xfaPdfBytes, {
 
 // Make modifications...
 
-// Save with XFA preservation
-const pdfBytes = await pdfDoc.save({ 
-  preserveXFA: true 
-})
+// Save the document
+const pdfBytes = await pdfDoc.save()
 ```
 
-**Note:** Without `preserveXFA: true`, XFA data will be removed when saving, which may cause the form to lose functionality.
+**Note:** The `preserveXFA` option must be set to `true` when loading to preserve XFA data. XFA preservation during save happens automatically if it was preserved during load.
 
 ### Extract XFA JavaScript
 
@@ -838,19 +838,20 @@ if (importButton) {
     }
   `
   
-  const success = pdfDoc.setXFAJavaScript(
-    'ImportButton',           // field name
-    importButton.event,       // event name (e.g., 'event__click')
-    newScript                 // new JavaScript code
-  )
-  
-  console.log(`Modification ${success ? 'succeeded' : 'failed'}`)
+  try {
+    pdfDoc.setXFAJavaScript(
+      'ImportButton',         // field name
+      importButton.event,     // event name (e.g., 'event__click')
+      newScript               // new JavaScript code
+    )
+    console.log('Successfully modified XFA JavaScript')
+  } catch (error) {
+    console.error('Failed to modify script:', error.message)
+  }
 }
 
-// Save with XFA preservation
-const pdfBytes = await pdfDoc.save({ 
-  preserveXFA: true 
-})
+// Save the document
+const pdfBytes = await pdfDoc.save()
 
 // The modified PDF will have the updated JavaScript
 ```
@@ -861,6 +862,40 @@ const pdfBytes = await pdfDoc.save({
 - Add logging for debugging
 - Customize import/export behavior
 - Fix compatibility issues
+
+### Extract Document JavaScript
+
+PDF documents can contain document-level JavaScript that executes when the document is opened. You can extract these scripts:
+
+<!-- prettier-ignore -->
+```js
+import { PDFDocument } from 'pdf-lib'
+
+const pdfBytes = ... // Load your PDF
+
+const pdfDoc = await PDFDocument.load(pdfBytes)
+
+// Extract all document-level JavaScript
+const scripts = pdfDoc.getDocumentJavaScripts()
+
+// Each script contains:
+// - name: The script name
+// - script: The JavaScript code
+
+console.log(`Found ${scripts.length} document scripts`)
+
+scripts.forEach((script) => {
+  console.log(`Script name: ${script.name}`)
+  console.log(`Code: ${script.script}`)
+})
+
+// Find specific scripts
+const initScripts = scripts.filter(s => 
+  s.name.toLowerCase().includes('init')
+)
+```
+
+**Note:** Document-level JavaScript is different from XFA JavaScript. Document-level scripts are stored in the document's Names dictionary and execute when the PDF is opened. XFA JavaScript is embedded in XFA form templates.
 
 ### Copy Pages
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Install with: `npm install @cantoo/pdf-lib`
   - [Create Form](#create-form)
   - [Fill Form](#fill-form)
   - [Flatten Form](#flatten-form)
+  - [Work with XFA Forms](#work-with-xfa-forms)
+  - [Extract XFA JavaScript](#extract-xfa-javascript)
+  - [Modify XFA JavaScript](#modify-xfa-javascript)
   - [Copy Pages](#copy-pages)
   - [Embed PNG and JPEG Images](#embed-png-and-jpeg-images)
   - [Embed PDF Pages](#embed-pdf-pages)
@@ -104,6 +107,9 @@ Install with: `npm install @cantoo/pdf-lib`
 - Create forms
 - Fill forms
 - Flatten forms
+- Preserve XFA forms
+- Extract XFA JavaScript
+- Modify XFA JavaScript
 - Add Pages
 - Insert Pages
 - Remove Pages
@@ -731,6 +737,130 @@ const pdfBytes = await pdfDoc.save()
 //   • Downloaded from the browser
 //   • Rendered in an <iframe>
 ```
+
+### Work with XFA Forms
+
+XFA (XML Forms Architecture) forms are complex, dynamic PDF forms commonly used for government forms, tax documents, and enterprise applications. Unlike standard AcroForms, XFA forms embed their structure and JavaScript in XML format.
+
+**Important:** To preserve XFA forms when loading and saving PDFs, use the `preserveXFA` option:
+
+<!-- prettier-ignore -->
+```js
+import { PDFDocument } from 'pdf-lib'
+
+const xfaPdfBytes = ... // Load your XFA PDF
+
+// Load with XFA preservation
+const pdfDoc = await PDFDocument.load(xfaPdfBytes, { 
+  preserveXFA: true 
+})
+
+// Make modifications...
+
+// Save with XFA preservation
+const pdfBytes = await pdfDoc.save({ 
+  preserveXFA: true 
+})
+```
+
+**Note:** Without `preserveXFA: true`, XFA data will be removed when saving, which may cause the form to lose functionality.
+
+### Extract XFA JavaScript
+
+XFA forms often contain JavaScript for validation, calculations, and data import/export. You can extract all JavaScript from an XFA form:
+
+<!-- prettier-ignore -->
+```js
+import { PDFDocument } from 'pdf-lib'
+
+const xfaPdfBytes = ... // Load your XFA PDF
+
+// Load the PDF with XFA preservation
+const pdfDoc = await PDFDocument.load(xfaPdfBytes, { 
+  preserveXFA: true 
+})
+
+// Extract all XFA JavaScript
+const scripts = pdfDoc.getXFAJavaScripts()
+
+// Each script contains:
+// - field: The field name (e.g., 'Button1', 'TextField2')
+// - event: The event name (e.g., 'event__click', 'event__change')
+// - script: The JavaScript code
+
+console.log(`Found ${scripts.length} scripts`)
+
+scripts.forEach((script) => {
+  console.log(`Field: ${script.field}`)
+  console.log(`Event: ${script.event}`)
+  console.log(`Code: ${script.script}`)
+})
+
+// Find specific scripts
+const clickHandlers = scripts.filter(s => 
+  s.event.includes('click')
+)
+
+const validationScripts = scripts.filter(s => 
+  s.script.includes('validate') || s.script.includes('Validate')
+)
+```
+
+### Modify XFA JavaScript
+
+You can modify JavaScript in XFA forms to customize behavior, add logging, or fix issues:
+
+<!-- prettier-ignore -->
+```js
+import { PDFDocument } from 'pdf-lib'
+
+const xfaPdfBytes = ... // Load your XFA PDF
+
+// Load the PDF with XFA preservation
+const pdfDoc = await PDFDocument.load(xfaPdfBytes, { 
+  preserveXFA: true 
+})
+
+// Extract scripts to find what you want to modify
+const scripts = pdfDoc.getXFAJavaScripts()
+const importButton = scripts.find(s => s.field === 'ImportButton')
+
+if (importButton) {
+  // Modify the import button's click handler
+  const newScript = `
+    // Custom import handler
+    try {
+      console.println("Starting import...");
+      ${importButton.script}
+      console.println("Import completed!");
+    } catch(e) {
+      xfa.host.messageBox("Error: " + e.message);
+    }
+  `
+  
+  const success = pdfDoc.setXFAJavaScript(
+    'ImportButton',           // field name
+    importButton.event,       // event name (e.g., 'event__click')
+    newScript                 // new JavaScript code
+  )
+  
+  console.log(`Modification ${success ? 'succeeded' : 'failed'}`)
+}
+
+// Save with XFA preservation
+const pdfBytes = await pdfDoc.save({ 
+  preserveXFA: true 
+})
+
+// The modified PDF will have the updated JavaScript
+```
+
+**Use Cases:**
+- Add error handling to existing scripts
+- Modify validation rules
+- Add logging for debugging
+- Customize import/export behavior
+- Fix compatibility issues
 
 ### Copy Pages
 

--- a/README.md
+++ b/README.md
@@ -765,6 +765,15 @@ const pdfBytes = await pdfDoc.save()
 
 **Note:** The `preserveXFA` option must be set to `true` when loading to preserve XFA data. XFA preservation during save happens automatically if it was preserved during load.
 
+**Scope and limitations (v1):** XFA support in pdf-lib is intentionally narrow and targets the common government/tax "static" XFA layout:
+
+- Only the array form of `/XFA` (alternating name/stream pairs) is supported; the single-stream packaging is not read or written.
+- Only the `template` packet is inspected — dynamic packaging and other packets (e.g. `datasets`, `config`, `xdp` wrappers) are not (re)generated. Editing JavaScript does not re-render or repackage the form.
+- XFA signature detection reads `<signature>`/`<manifest>` entries from the template; it does not validate or create cryptographic signatures.
+- `getForm()` removes XFA data unless the document was loaded with `preserveXFA: true`, so call the XFA helpers before `getForm()` (or load with `preserveXFA: true`).
+- Template XML is decoded as UTF-8 with a latin1 fallback; exotic encodings may not round-trip cleanly.
+
+
 ### Extract XFA JavaScript
 
 XFA forms often contain JavaScript for validation, calculations, and data import/export. You can extract all JavaScript from an XFA form:

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -67,6 +67,7 @@ import {
   BinaryData,
   Cache,
   canBeConvertedToUint8Array,
+  decodeXfaXml,
   encodeToBase64,
   isStandardFont,
   pluckIndices,
@@ -344,6 +345,15 @@ export default class PDFDocument {
    *   console.log(`${type}: ${name}`)
    * })
    * ```
+   *
+   * **XFA caveat:** if the document contains XFA form data and it was **not**
+   * loaded with `preserveXFA: true`, calling this method strips the XFA data
+   * (pdf-lib cannot render or edit XFA and removes it to keep the AcroForm
+   * consistent). Because the XFA read/write helpers ([[getXFAJavaScripts]],
+   * [[setXFAJavaScript]]) operate on that same data, call them **before**
+   * `getForm()` — or load with `preserveXFA: true`
+   * otherwise the XFA will already be gone.
+   *
    * @returns The form for this document.
    */
   getForm(): PDFForm {
@@ -1164,6 +1174,10 @@ export default class PDFDocument {
    *   console.log(`Field "${field}" on ${event}:`, script)
    * })
    * ```
+   *
+   * **Note:** load the document with `preserveXFA: true` and call this before
+   * [[getForm]], which strips XFA data when `preserveXFA` is not set.
+   *
    * @returns An array of objects containing field names, events, and JavaScript code.
    */
   getXFAJavaScripts(): Array<{ field: string; event: string; script: string }> {
@@ -1176,9 +1190,7 @@ export default class PDFDocument {
 
     try {
       const xmlBytes = decodePDFRawStream(templateInfo.stream).decode();
-      const xmlString = new TextDecoder('utf-8', { fatal: true }).decode(
-        xmlBytes,
-      );
+      const xmlString = decodeXfaXml(xmlBytes);
 
       const doc = parseHtml(this.normalizeXfaXml(xmlString), { script: true });
 
@@ -1217,6 +1229,9 @@ export default class PDFDocument {
    * @param eventName The name of the event (e.g., 'event__click', 'calculate')
    * @param newScript The new JavaScript code to set
    * @throws Error if the XFA form is not found, the script location is not found, or decoding fails
+   *
+   * **Note:** load the document with `preserveXFA: true` and call this before
+   * [[getForm]], which strips XFA data when `preserveXFA` is not set.
    */
   setXFAJavaScript(
     fieldName: string,
@@ -1233,7 +1248,7 @@ export default class PDFDocument {
     let xmlString: string;
     try {
       const xmlBytes = decodePDFRawStream(templateInfo.stream).decode();
-      xmlString = new TextDecoder('utf-8', { fatal: true }).decode(xmlBytes);
+      xmlString = decodeXfaXml(xmlBytes);
     } catch (error) {
       throw new Error(
         `Failed to decode XFA template stream: ${error instanceof Error ? error.message : String(error)}`,
@@ -1243,23 +1258,51 @@ export default class PDFDocument {
     const normalizedXml = this.normalizeXfaXml(xmlString);
     const doc = parseHtml(normalizedXml, { script: true });
 
-    const entry = this.collectXFAScripts(doc).find(
+    const entries = this.collectXFAScripts(doc).filter(
       (e) => e.field === fieldName && e.event === eventName,
     );
 
-    if (!entry) {
+    if (entries.length === 0) {
       throw new Error(
         `Script not found for field "${fieldName}" and event "${eventName}". ` +
-        'Verify the field and event names exist in the XFA template.',
+          'Verify the field and event names exist in the XFA template.',
       );
     }
 
-    const oldOuter = entry.scriptNode.outerHTML;
-    const tagOpen = oldOuter.match(/^(<script[^>]*>)/i)?.[1] ?? '<script>';
-    const newOuter = `${tagOpen}${this.escapeXML(newScript)}</script>`;
-    const updatedXml = normalizedXml
-      .replace(oldOuter, newOuter)
-      .replace(/xfa-template/g, 'template');
+    // Replace every matching <script> node rather than only the first one.
+    // Work through the entries in document order and consume one occurrence of
+    // each node's serialized form per iteration, so duplicated script bodies
+    // for the same (field, event) are each updated exactly once instead of the
+    // first occurrence being overwritten repeatedly.
+    //
+    // Note: this still relies on the parser's `outerHTML` matching the source
+    // bytes. If two logically-distinct scripts serialize identically and appear
+    // out of document order the mapping is ambiguous; such XFA templates are not
+    // supported. When the serialized form cannot be located at all abort instead
+    // of silently returning an unchanged document.
+    let updatedXml = normalizedXml;
+    for (const entry of entries) {
+      const oldOuter = entry.scriptNode.outerHTML;
+      const tagOpen = oldOuter.match(/^(<script[^>]*>)/i)?.[1] ?? '<script>';
+      const newOuter = `${tagOpen}${this.escapeXML(newScript)}</script>`;
+
+      const index = updatedXml.indexOf(oldOuter);
+      if (index === -1) {
+        throw new Error(
+          `Unable to locate the serialized <script> for field "${fieldName}" ` +
+            `and event "${eventName}" in the XFA template. The parsed ` +
+            'representation does not match the source bytes, so the update was ' +
+            'aborted to avoid corrupting the document.',
+        );
+      }
+
+      updatedXml =
+        updatedXml.slice(0, index) +
+        newOuter +
+        updatedXml.slice(index + oldOuter.length);
+    }
+
+    updatedXml = updatedXml.replace(/xfa-template/g, 'template');
 
     const newXmlBytes = new TextEncoder().encode(updatedXml);
     const filter = templateInfo.stream.dict.get(PDFName.of('Filter'));
@@ -1269,12 +1312,22 @@ export default class PDFDocument {
         : this.context.stream(newXmlBytes);
 
     if (templateInfo.streamRef) {
-      this.context.delete(templateInfo.streamRef);
+      // Overwrite the existing template stream in place, preserving its object
+      // reference. Creating a new object and re-pointing the XFA array does not
+      // survive a save/reload for documents whose objects live in compressed
+      // object streams, because the re-emitted stale copy wins on the next load.
+      this.context.assign(templateInfo.streamRef, newStream);
+      if (this.context.snapshot) {
+        this.context.snapshot.markRefForSave(templateInfo.streamRef);
+      }
+    } else {
+      // The template was stored as a direct (inline) stream; replace the array
+      // slot with a freshly registered stream object.
+      templateInfo.xfa.set(
+        templateInfo.templateIndex,
+        this.context.register(newStream),
+      );
     }
-    templateInfo.xfa.set(
-      templateInfo.templateIndex,
-      this.context.register(newStream),
-    );
   }
 
   /**
@@ -1579,11 +1632,11 @@ export default class PDFDocument {
       const fontkit = this.assertFontkit();
       embedder = subset
         ? await CustomFontSubsetEmbedder.for(
-          fontkit,
-          bytes,
-          customName,
-          features,
-        )
+            fontkit,
+            bytes,
+            customName,
+            features,
+          )
         : await CustomFontEmbedder.for(fontkit, bytes, customName, features);
     } else {
       throw new TypeError(
@@ -1962,7 +2015,7 @@ export default class PDFDocument {
       ).serializeToBuffer();
       const result = new Uint8Array(
         this.context.pdfFileDetails.originalBytes!.byteLength +
-        increment.byteLength,
+          increment.byteLength,
       );
       result.set(this.context.pdfFileDetails.originalBytes!);
       result.set(

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -1023,6 +1023,138 @@ export default class PDFDocument {
   }
 
   /**
+   * Helper method to escape XML special characters in script content
+   */
+  private escapeXML(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  /**
+   * Normalizes XFA template XML so that node-html-better-parser can parse it
+   * correctly. XFA uses \n> to close opening tags, and the HTML parser treats
+   * <template> as a special inert element, so both need to be worked around.
+   */
+  private normalizeXfaXml(xml: string): string {
+    return xml
+      .replace(/\n>/g, '>')
+      .replace(/<template(\s)/g, '<xfa-template$1')
+      .replace(/<template>/g, '<xfa-template>')
+      .replace(/<\/template>/g, '</xfa-template>');
+  }
+
+  /**
+   * Recursively collects all <script> nodes from the XFA XML tree that have a
+   * valid enclosing field and event context.
+   */
+  private collectXFAScripts(
+    node: HTMLElement,
+    currentField?: string,
+    currentEvent?: string,
+  ): Array<{ scriptNode: HTMLElement; field: string; event: string }> {
+    const results: Array<{
+      scriptNode: HTMLElement;
+      field: string;
+      event: string;
+    }> = [];
+
+    const tag = node.tagName?.toLowerCase();
+    let fieldCtx = currentField;
+    let eventCtx = currentEvent;
+
+    if (tag === 'field') {
+      fieldCtx = node.getAttribute('name') ?? undefined;
+      eventCtx = undefined;
+    } else if (tag === 'event') {
+      eventCtx = node.getAttribute('name') ?? undefined;
+    } else if (tag === 'script') {
+      if (fieldCtx && eventCtx) {
+        results.push({ scriptNode: node, field: fieldCtx, event: eventCtx });
+      }
+    }
+
+    for (const child of node.childNodes) {
+      if (child.nodeType === NodeType.ELEMENT_NODE) {
+        results.push(
+          ...this.collectXFAScripts(child as HTMLElement, fieldCtx, eventCtx),
+        );
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Helper method to extract XFA template information
+   */
+  private getXFATemplateInfo(): {
+    xfa: PDFArray;
+    templateIndex: number;
+    streamRef: PDFRef | null;
+    stream: PDFRawStream;
+  } | null {
+    const acroForm = this.catalog.get(PDFName.of('AcroForm'));
+    if (
+      !acroForm ||
+      !(acroForm instanceof PDFDict || acroForm instanceof PDFRef)
+    ) {
+      return null;
+    }
+
+    const formDict =
+      acroForm instanceof PDFRef
+        ? this.context.lookup(acroForm, PDFDict)
+        : acroForm;
+
+    const xfaObj = formDict.get(PDFName.of('XFA'));
+    if (!xfaObj) {
+      return null;
+    }
+
+    const xfa = xfaObj instanceof PDFRef ? this.context.lookup(xfaObj) : xfaObj;
+
+    if (!(xfa instanceof PDFArray)) {
+      return null;
+    }
+
+    for (let idx = 0; idx < xfa.size(); idx += 2) {
+      const nameObj = xfa.get(idx);
+      const streamObj = xfa.get(idx + 1);
+
+      if (!nameObj || !streamObj) continue;
+
+      let sectionName: string;
+      if (nameObj instanceof PDFString) {
+        sectionName = nameObj.asString();
+      } else if (nameObj instanceof PDFHexString) {
+        sectionName = nameObj.decodeText();
+      } else {
+        continue;
+      }
+
+      if (sectionName !== 'template') continue;
+
+      const streamRef = streamObj instanceof PDFRef ? streamObj : null;
+      const stream = streamRef ? this.context.lookup(streamRef) : streamObj;
+
+      if (!stream || !(stream instanceof PDFRawStream)) continue;
+
+      return {
+        xfa,
+        templateIndex: idx + 1,
+        streamRef,
+        stream,
+      };
+    }
+
+    return null;
+  }
+
+  /**
    * Get all JavaScript from XFA form template.
    * XFA forms can contain JavaScript in <script> elements within the template XML.
    * For example:
@@ -1037,106 +1169,39 @@ export default class PDFDocument {
   getXFAJavaScripts(): Array<{ field: string; event: string; script: string }> {
     const scripts: Array<{ field: string; event: string; script: string }> = [];
 
-    const acroForm = this.catalog.get(PDFName.of('AcroForm'));
-    if (
-      !acroForm ||
-      !(acroForm instanceof PDFDict || acroForm instanceof PDFRef)
-    ) {
+    const templateInfo = this.getXFATemplateInfo();
+    if (!templateInfo) {
       return scripts;
     }
 
-    const formDict =
-      acroForm instanceof PDFRef
-        ? this.context.lookup(acroForm, PDFDict)
-        : acroForm;
+    try {
+      const xmlBytes = decodePDFRawStream(templateInfo.stream).decode();
+      const xmlString = new TextDecoder('utf-8', { fatal: true }).decode(
+        xmlBytes,
+      );
 
-    const xfaObj = formDict.get(PDFName.of('XFA'));
-    if (!xfaObj) {
-      return scripts;
-    }
+      const doc = parseHtml(this.normalizeXfaXml(xmlString), { script: true });
 
-    // XFA might be a reference to an array
-    const xfa = xfaObj instanceof PDFRef ? this.context.lookup(xfaObj) : xfaObj;
-
-    if (!(xfa instanceof PDFArray)) {
-      return scripts;
-    }
-
-    // XFA is an array of [name1, stream1, name2, stream2, ...]
-    for (let idx = 0; idx < xfa.size(); idx += 2) {
-      const nameObj = xfa.get(idx);
-      const streamObj = xfa.get(idx + 1);
-
-      if (!nameObj || !streamObj) continue;
-
-      let sectionName: string;
-      if (nameObj instanceof PDFString) {
-        sectionName = nameObj.asString();
-      } else if (nameObj instanceof PDFHexString) {
-        sectionName = nameObj.decodeText();
-      } else {
-        continue;
+      for (const script of this.collectXFAScripts(doc)) {
+        const scriptContent = script.scriptNode.text?.trim();
+        if (scriptContent) {
+          scripts.push({
+            field: script.field,
+            event: script.event,
+            script: scriptContent,
+          });
+        }
       }
-
-      // We're interested in the 'template' section
-      if (sectionName !== 'template') continue;
-
-      const streamRef = streamObj instanceof PDFRef ? streamObj : null;
-      const stream = streamRef ? this.context.lookup(streamRef) : streamObj;
-
-      if (!stream || !(stream instanceof PDFRawStream)) continue;
-
-      const xmlBytes = decodePDFRawStream(stream).decode();
-      const xmlString = new TextDecoder().decode(xmlBytes);
-
-      // Extract JavaScript from <script> tags
-      // Note: XFA uses newlines in closing tags like </script\n>
-      const scriptMatches: Array<{
-        field: string;
-        event: string;
-        script: string;
-      }> = [];
-      const scriptPattern = /<script[^>]*>\s*([\s\S]*?)\s*<\/script\s*>/gi;
-      let scriptMatch;
-
-      while ((scriptMatch = scriptPattern.exec(xmlString)) !== null) {
-        const scriptCode = scriptMatch[1].trim();
-        if (!scriptCode) continue;
-
-        // Find the enclosing field and event by looking backwards
-        const beforeScript = xmlString.substring(
-          Math.max(0, scriptMatch.index - 2000),
-          scriptMatch.index,
-        );
-
-        // Find field name
-        const fieldNameMatch = beforeScript.match(
-          /<field[^>]*name="([^"]*)"[^>]*>/gi,
-        );
-        const fieldName = fieldNameMatch
-          ? fieldNameMatch[fieldNameMatch.length - 1].match(
-            /name="([^"]*)"/,
-          )?.[1] || 'unknown'
-          : 'unknown';
-
-        // Find event name
-        const eventNameMatch = beforeScript.match(
-          /<event[^>]*name="([^"]*)"[^>]*>/gi,
-        );
-        const eventName = eventNameMatch
-          ? eventNameMatch[eventNameMatch.length - 1].match(
-            /name="([^"]*)"/,
-          )?.[1] || 'unknown'
-          : 'unknown';
-
-        scriptMatches.push({
-          field: fieldName,
-          event: eventName,
-          script: scriptCode,
-        });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('decode')) {
+          throw new Error(
+            `Failed to decode XFA template stream: Invalid UTF-8 encoding. ${error.message}`,
+          );
+        }
+        throw new Error(`Failed to parse XFA template: ${error.message}`);
       }
-
-      scripts.push(...scriptMatches);
+      throw error;
     }
 
     return scripts;
@@ -1151,83 +1216,65 @@ export default class PDFDocument {
    * @param fieldName The name of the field containing the script
    * @param eventName The name of the event (e.g., 'event__click', 'calculate')
    * @param newScript The new JavaScript code to set
-   * @returns True if the script was found and updated, false otherwise
+   * @throws Error if the XFA form is not found, the script location is not found, or decoding fails
    */
   setXFAJavaScript(
     fieldName: string,
     eventName: string,
     newScript: string,
-  ): boolean {
-    const acroForm = this.catalog.get(PDFName.of('AcroForm'));
-    if (
-      !acroForm ||
-      !(acroForm instanceof PDFDict || acroForm instanceof PDFRef)
-    ) {
-      return false;
-    }
-
-    const formDict =
-      acroForm instanceof PDFRef
-        ? this.context.lookup(acroForm, PDFDict)
-        : acroForm;
-
-    const xfa = formDict.get(PDFName.of('XFA'));
-    if (!xfa || !(xfa instanceof PDFArray)) {
-      return false;
-    }
-
-    // Find template section
-    for (let idx = 0; idx < xfa.size(); idx += 2) {
-      const nameObj = xfa.get(idx);
-      const streamObj = xfa.get(idx + 1);
-
-      if (!nameObj || !streamObj) continue;
-
-      let sectionName: string;
-      if (nameObj instanceof PDFString) {
-        sectionName = nameObj.asString();
-      } else if (nameObj instanceof PDFHexString) {
-        sectionName = nameObj.decodeText();
-      } else {
-        continue;
-      }
-
-      if (sectionName !== 'template') continue;
-
-      const streamRef = streamObj instanceof PDFRef ? streamObj : null;
-      const stream = streamRef ? this.context.lookup(streamRef) : streamObj;
-
-      if (!stream || !(stream instanceof PDFRawStream)) continue;
-
-      const xmlBytes = decodePDFRawStream(stream).decode();
-      let xmlString = new TextDecoder().decode(xmlBytes);
-
-      // Find and replace the script
-      // Note: XFA uses newlines in closing tags like </script\n>
-      const fieldPattern = new RegExp(
-        `(<field[^>]*name="${fieldName}"[^>]*>[\\s\\S]*?<event[^>]*name="${eventName}"[^>]*>[\\s\\S]*?<script[^>]*>)\\s*[\\s\\S]*?\\s*(<\\/script\\s*>)`,
-        'i',
+  ): void {
+    const templateInfo = this.getXFATemplateInfo();
+    if (!templateInfo) {
+      throw new Error(
+        'XFA form not found in document. Ensure the document has XFA forms and was loaded with preserveXFA: true.',
       );
-
-      const match = xmlString.match(fieldPattern);
-      if (!match) continue;
-
-      xmlString = xmlString.replace(fieldPattern, `$1\n${newScript}\n$2`);
-
-      // Create new stream with modified XML
-      const newXmlBytes = new TextEncoder().encode(xmlString);
-      const newStream = this.context.stream(newXmlBytes);
-
-      // Replace in XFA array
-      if (streamRef) {
-        this.context.delete(streamRef);
-      }
-      xfa.set(idx + 1, this.context.register(newStream));
-
-      return true;
     }
 
-    return false;
+    let xmlString: string;
+    try {
+      const xmlBytes = decodePDFRawStream(templateInfo.stream).decode();
+      xmlString = new TextDecoder('utf-8', { fatal: true }).decode(xmlBytes);
+    } catch (error) {
+      throw new Error(
+        `Failed to decode XFA template stream: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const normalizedXml = this.normalizeXfaXml(xmlString);
+    const doc = parseHtml(normalizedXml, { script: true });
+
+    const entry = this.collectXFAScripts(doc).find(
+      (e) => e.field === fieldName && e.event === eventName,
+    );
+
+    if (!entry) {
+      throw new Error(
+        `Script not found for field "${fieldName}" and event "${eventName}". ` +
+        'Verify the field and event names exist in the XFA template.',
+      );
+    }
+
+    const oldOuter = entry.scriptNode.outerHTML;
+    const tagOpen = oldOuter.match(/^(<script[^>]*>)/i)?.[1] ?? '<script>';
+    const newOuter = `${tagOpen}${this.escapeXML(newScript)}</script>`;
+    const updatedXml = normalizedXml
+      .replace(oldOuter, newOuter)
+      .replace(/xfa-template/g, 'template');
+
+    const newXmlBytes = new TextEncoder().encode(updatedXml);
+    const filter = templateInfo.stream.dict.get(PDFName.of('Filter'));
+    const newStream =
+      filter !== undefined
+        ? this.context.flateStream(newXmlBytes)
+        : this.context.stream(newXmlBytes);
+
+    if (templateInfo.streamRef) {
+      this.context.delete(templateInfo.streamRef);
+    }
+    templateInfo.xfa.set(
+      templateInfo.templateIndex,
+      this.context.register(newStream),
+    );
   }
 
   /**

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -171,6 +171,7 @@ export default class PDFDocument {
       capNumbers = false,
       password,
       forIncrementalUpdate = false,
+      preserveXFA = false,
     } = options;
 
     assertIs(pdf, 'pdf', ['string', ArrayBuffer, 'ArrayBufferView']);
@@ -211,11 +212,23 @@ export default class PDFDocument {
         ),
         forIncrementalUpdate,
       ).parseDocument();
-      const pdfDoc = new PDFDocument(decryptedContext, true, updateMetadata);
+      const pdfDoc = new PDFDocument(
+        decryptedContext,
+        true,
+        updateMetadata,
+        false,
+        preserveXFA,
+      );
       if (forIncrementalUpdate) pdfDoc.takeSnapshot();
       return pdfDoc;
     } else {
-      const pdfDoc = new PDFDocument(context, ignoreEncryption, updateMetadata);
+      const pdfDoc = new PDFDocument(
+        context,
+        ignoreEncryption,
+        updateMetadata,
+        false,
+        preserveXFA,
+      );
       if (forIncrementalUpdate) pdfDoc.takeSnapshot();
       return pdfDoc;
     }
@@ -259,14 +272,19 @@ export default class PDFDocument {
   private readonly embeddedPages: PDFEmbeddedPage[];
   private readonly embeddedFiles: PDFEmbeddedFile[];
   private readonly javaScripts: PDFJavaScript[];
+  private readonly isNewDocument: boolean;
+  private readonly preserveXFA: boolean;
 
   private constructor(
     context: PDFContext,
     ignoreEncryption: boolean,
     updateMetadata: boolean,
+    isNewDocument = false,
+    preserveXFA = false,
   ) {
     assertIs(context, 'context', [[PDFContext, 'PDFContext']]);
     assertIs(ignoreEncryption, 'ignoreEncryption', ['boolean']);
+    assertIs(preserveXFA, 'preserveXFA', ['boolean']);
 
     this.context = context;
     this.catalog = context.lookup(context.trailerInfo.Root) as PDFCatalog;
@@ -285,6 +303,7 @@ export default class PDFDocument {
     this.embeddedPages = [];
     this.embeddedFiles = [];
     this.javaScripts = [];
+    this.preserveXFA = preserveXFA;
 
     if (!ignoreEncryption && this.isEncrypted) throw new EncryptedPDFError();
 
@@ -329,9 +348,9 @@ export default class PDFDocument {
    */
   getForm(): PDFForm {
     const form = this.formCache.access();
-    if (form.hasXFA()) {
+    if (form.hasXFA() && !this.preserveXFA) {
       console.warn(
-        'Removing XFA form data as pdf-lib does not support reading or writing XFA',
+        'Removing XFA form data as pdf-lib does not support reading or writing XFA. Set preserveXFA: true in load options to keep XFA data.',
       );
       form.deleteXFA();
     }
@@ -917,6 +936,301 @@ export default class PDFDocument {
   }
 
   /**
+   * Get all document-level JavaScript scripts from the document's Names dictionary.
+   * These scripts are executed when the document is opened.
+   * For example:
+   * ```js
+   * const scripts = pdfDoc.getDocumentJavaScripts()
+   * scripts.forEach(({ name, script }) => {
+   *   console.log(`Script "${name}":`, script)
+   * })
+   * ```
+   * @returns An array of objects containing script names and their JavaScript code.
+   */
+  getDocumentJavaScripts(): Array<{ name: string; script: string }> {
+    const scripts: Array<{ name: string; script: string }> = [];
+
+    const names = this.catalog.get(PDFName.of('Names'));
+    if (!names || !(names instanceof PDFDict || names instanceof PDFRef)) {
+      return scripts;
+    }
+
+    const namesDict =
+      names instanceof PDFRef ? this.context.lookup(names, PDFDict) : names;
+
+    const javascript = namesDict.get(PDFName.of('JavaScript'));
+    if (
+      !javascript ||
+      !(javascript instanceof PDFDict || javascript instanceof PDFRef)
+    ) {
+      return scripts;
+    }
+
+    const javascriptDict =
+      javascript instanceof PDFRef
+        ? this.context.lookup(javascript, PDFDict)
+        : javascript;
+
+    const jsNames = javascriptDict.get(PDFName.of('Names'));
+    if (!jsNames || !(jsNames instanceof PDFArray)) {
+      return scripts;
+    }
+
+    // Names array is a flat array of [name1, dict1, name2, dict2, ...]
+    for (let idx = 0; idx < jsNames.size(); idx += 2) {
+      const nameObj = jsNames.get(idx);
+      const actionObj = jsNames.get(idx + 1);
+
+      if (!nameObj || !actionObj) continue;
+
+      let name: string;
+      if (nameObj instanceof PDFString) {
+        name = nameObj.asString();
+      } else if (nameObj instanceof PDFHexString) {
+        name = nameObj.decodeText();
+      } else {
+        continue;
+      }
+
+      let actionDict: PDFDict;
+      if (actionObj instanceof PDFRef) {
+        actionDict = this.context.lookup(actionObj, PDFDict);
+      } else if (actionObj instanceof PDFDict) {
+        actionDict = actionObj;
+      } else {
+        continue;
+      }
+
+      const s = actionDict.lookup(PDFName.of('S'));
+      if (!(s instanceof PDFName) || s.asString() !== '/JavaScript') {
+        continue;
+      }
+
+      const js = actionDict.lookup(PDFName.of('JS'));
+      let script: string;
+      if (js instanceof PDFString) {
+        script = js.asString();
+      } else if (js instanceof PDFHexString) {
+        script = js.decodeText();
+      } else {
+        continue;
+      }
+
+      scripts.push({ name, script });
+    }
+
+    return scripts;
+  }
+
+  /**
+   * Get all JavaScript from XFA form template.
+   * XFA forms can contain JavaScript in <script> elements within the template XML.
+   * For example:
+   * ```js
+   * const xfaScripts = pdfDoc.getXFAJavaScripts()
+   * xfaScripts.forEach(({ field, event, script }) => {
+   *   console.log(`Field "${field}" on ${event}:`, script)
+   * })
+   * ```
+   * @returns An array of objects containing field names, events, and JavaScript code.
+   */
+  getXFAJavaScripts(): Array<{ field: string; event: string; script: string }> {
+    const scripts: Array<{ field: string; event: string; script: string }> = [];
+
+    const acroForm = this.catalog.get(PDFName.of('AcroForm'));
+    if (
+      !acroForm ||
+      !(acroForm instanceof PDFDict || acroForm instanceof PDFRef)
+    ) {
+      return scripts;
+    }
+
+    const formDict =
+      acroForm instanceof PDFRef
+        ? this.context.lookup(acroForm, PDFDict)
+        : acroForm;
+
+    const xfaObj = formDict.get(PDFName.of('XFA'));
+    if (!xfaObj) {
+      return scripts;
+    }
+
+    // XFA might be a reference to an array
+    const xfa = xfaObj instanceof PDFRef ? this.context.lookup(xfaObj) : xfaObj;
+
+    if (!(xfa instanceof PDFArray)) {
+      return scripts;
+    }
+
+    // XFA is an array of [name1, stream1, name2, stream2, ...]
+    for (let idx = 0; idx < xfa.size(); idx += 2) {
+      const nameObj = xfa.get(idx);
+      const streamObj = xfa.get(idx + 1);
+
+      if (!nameObj || !streamObj) continue;
+
+      let sectionName: string;
+      if (nameObj instanceof PDFString) {
+        sectionName = nameObj.asString();
+      } else if (nameObj instanceof PDFHexString) {
+        sectionName = nameObj.decodeText();
+      } else {
+        continue;
+      }
+
+      // We're interested in the 'template' section
+      if (sectionName !== 'template') continue;
+
+      const streamRef = streamObj instanceof PDFRef ? streamObj : null;
+      const stream = streamRef ? this.context.lookup(streamRef) : streamObj;
+
+      if (!stream || !(stream instanceof PDFRawStream)) continue;
+
+      const xmlBytes = decodePDFRawStream(stream).decode();
+      const xmlString = new TextDecoder().decode(xmlBytes);
+
+      // Extract JavaScript from <script> tags
+      // Note: XFA uses newlines in closing tags like </script\n>
+      const scriptMatches: Array<{
+        field: string;
+        event: string;
+        script: string;
+      }> = [];
+      const scriptPattern = /<script[^>]*>\s*([\s\S]*?)\s*<\/script\s*>/gi;
+      let scriptMatch;
+
+      while ((scriptMatch = scriptPattern.exec(xmlString)) !== null) {
+        const scriptCode = scriptMatch[1].trim();
+        if (!scriptCode) continue;
+
+        // Find the enclosing field and event by looking backwards
+        const beforeScript = xmlString.substring(
+          Math.max(0, scriptMatch.index - 2000),
+          scriptMatch.index,
+        );
+
+        // Find field name
+        const fieldNameMatch = beforeScript.match(
+          /<field[^>]*name="([^"]*)"[^>]*>/gi,
+        );
+        const fieldName = fieldNameMatch
+          ? fieldNameMatch[fieldNameMatch.length - 1].match(
+            /name="([^"]*)"/,
+          )?.[1] || 'unknown'
+          : 'unknown';
+
+        // Find event name
+        const eventNameMatch = beforeScript.match(
+          /<event[^>]*name="([^"]*)"[^>]*>/gi,
+        );
+        const eventName = eventNameMatch
+          ? eventNameMatch[eventNameMatch.length - 1].match(
+            /name="([^"]*)"/,
+          )?.[1] || 'unknown'
+          : 'unknown';
+
+        scriptMatches.push({
+          field: fieldName,
+          event: eventName,
+          script: scriptCode,
+        });
+      }
+
+      scripts.push(...scriptMatches);
+    }
+
+    return scripts;
+  }
+
+  /**
+   * Modify JavaScript in XFA form template for a specific field and event.
+   * For example:
+   * ```js
+   * pdfDoc.setXFAJavaScript('import', 'event__click', 'console.println("Modified!");')
+   * ```
+   * @param fieldName The name of the field containing the script
+   * @param eventName The name of the event (e.g., 'event__click', 'calculate')
+   * @param newScript The new JavaScript code to set
+   * @returns True if the script was found and updated, false otherwise
+   */
+  setXFAJavaScript(
+    fieldName: string,
+    eventName: string,
+    newScript: string,
+  ): boolean {
+    const acroForm = this.catalog.get(PDFName.of('AcroForm'));
+    if (
+      !acroForm ||
+      !(acroForm instanceof PDFDict || acroForm instanceof PDFRef)
+    ) {
+      return false;
+    }
+
+    const formDict =
+      acroForm instanceof PDFRef
+        ? this.context.lookup(acroForm, PDFDict)
+        : acroForm;
+
+    const xfa = formDict.get(PDFName.of('XFA'));
+    if (!xfa || !(xfa instanceof PDFArray)) {
+      return false;
+    }
+
+    // Find template section
+    for (let idx = 0; idx < xfa.size(); idx += 2) {
+      const nameObj = xfa.get(idx);
+      const streamObj = xfa.get(idx + 1);
+
+      if (!nameObj || !streamObj) continue;
+
+      let sectionName: string;
+      if (nameObj instanceof PDFString) {
+        sectionName = nameObj.asString();
+      } else if (nameObj instanceof PDFHexString) {
+        sectionName = nameObj.decodeText();
+      } else {
+        continue;
+      }
+
+      if (sectionName !== 'template') continue;
+
+      const streamRef = streamObj instanceof PDFRef ? streamObj : null;
+      const stream = streamRef ? this.context.lookup(streamRef) : streamObj;
+
+      if (!stream || !(stream instanceof PDFRawStream)) continue;
+
+      const xmlBytes = decodePDFRawStream(stream).decode();
+      let xmlString = new TextDecoder().decode(xmlBytes);
+
+      // Find and replace the script
+      // Note: XFA uses newlines in closing tags like </script\n>
+      const fieldPattern = new RegExp(
+        `(<field[^>]*name="${fieldName}"[^>]*>[\\s\\S]*?<event[^>]*name="${eventName}"[^>]*>[\\s\\S]*?<script[^>]*>)\\s*[\\s\\S]*?\\s*(<\\/script\\s*>)`,
+        'i',
+      );
+
+      const match = xmlString.match(fieldPattern);
+      if (!match) continue;
+
+      xmlString = xmlString.replace(fieldPattern, `$1\n${newScript}\n$2`);
+
+      // Create new stream with modified XML
+      const newXmlBytes = new TextEncoder().encode(xmlString);
+      const newStream = this.context.stream(newXmlBytes);
+
+      // Replace in XFA array
+      if (streamRef) {
+        this.context.delete(streamRef);
+      }
+      xfa.set(idx + 1, this.context.register(newStream));
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Add an attachment to this document. Attachments are visible in the
    * "Attachments" panel of Adobe Acrobat and some other PDF readers. Any
    * type of file can be added as an attachment. This includes, but is not
@@ -1218,11 +1532,11 @@ export default class PDFDocument {
       const fontkit = this.assertFontkit();
       embedder = subset
         ? await CustomFontSubsetEmbedder.for(
-            fontkit,
-            bytes,
-            customName,
-            features,
-          )
+          fontkit,
+          bytes,
+          customName,
+          features,
+        )
         : await CustomFontEmbedder.for(fontkit, bytes, customName, features);
     } else {
       throw new TypeError(
@@ -1601,7 +1915,7 @@ export default class PDFDocument {
       ).serializeToBuffer();
       const result = new Uint8Array(
         this.context.pdfFileDetails.originalBytes!.byteLength +
-          increment.byteLength,
+        increment.byteLength,
       );
       result.set(this.context.pdfFileDetails.originalBytes!);
       result.set(

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -78,6 +78,7 @@ import FileEmbedder, { AFRelationship } from '../core/embedders/FileEmbedder';
 import PDFEmbeddedFile from './PDFEmbeddedFile';
 import PDFJavaScript from './PDFJavaScript';
 import JavaScriptEmbedder from '../core/embedders/JavaScriptEmbedder';
+import PDFJavaScriptAction from './PDFJavaScriptAction';
 import { CipherTransformFactory } from '../core/crypto';
 import PDFSvg from './PDFSvg';
 import PDFSecurity, { SecurityOptions } from '../core/security/PDFSecurity';
@@ -217,7 +218,6 @@ export default class PDFDocument {
         decryptedContext,
         true,
         updateMetadata,
-        false,
         preserveXFA,
       );
       if (forIncrementalUpdate) pdfDoc.takeSnapshot();
@@ -227,7 +227,6 @@ export default class PDFDocument {
         context,
         ignoreEncryption,
         updateMetadata,
-        false,
         preserveXFA,
       );
       if (forIncrementalUpdate) pdfDoc.takeSnapshot();
@@ -273,14 +272,12 @@ export default class PDFDocument {
   private readonly embeddedPages: PDFEmbeddedPage[];
   private readonly embeddedFiles: PDFEmbeddedFile[];
   private readonly javaScripts: PDFJavaScript[];
-  private readonly isNewDocument: boolean;
   private readonly preserveXFA: boolean;
 
   private constructor(
     context: PDFContext,
     ignoreEncryption: boolean,
     updateMetadata: boolean,
-    isNewDocument = false,
     preserveXFA = false,
   ) {
     assertIs(context, 'context', [[PDFContext, 'PDFContext']]);
@@ -1011,20 +1008,9 @@ export default class PDFDocument {
         continue;
       }
 
-      const s = actionDict.lookup(PDFName.of('S'));
-      if (!(s instanceof PDFName) || s.asString() !== '/JavaScript') {
-        continue;
-      }
-
-      const js = actionDict.lookup(PDFName.of('JS'));
-      let script: string;
-      if (js instanceof PDFString) {
-        script = js.asString();
-      } else if (js instanceof PDFHexString) {
-        script = js.decodeText();
-      } else {
-        continue;
-      }
+      const action = PDFJavaScriptAction.of(actionDict, this);
+      const script = action?.getScript();
+      if (!script) continue;
 
       scripts.push({ name, script });
     }
@@ -1042,19 +1028,6 @@ export default class PDFDocument {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
-  }
-
-  /**
-   * Normalizes XFA template XML so that node-html-better-parser can parse it
-   * correctly. XFA uses \n> to close opening tags, and the HTML parser treats
-   * <template> as a special inert element, so both need to be worked around.
-   */
-  private normalizeXfaXml(xml: string): string {
-    return xml
-      .replace(/\n>/g, '>')
-      .replace(/<template(\s)/g, '<xfa-template$1')
-      .replace(/<template>/g, '<xfa-template>')
-      .replace(/<\/template>/g, '</xfa-template>');
   }
 
   /**
@@ -1192,7 +1165,7 @@ export default class PDFDocument {
       const xmlBytes = decodePDFRawStream(templateInfo.stream).decode();
       const xmlString = decodeXfaXml(xmlBytes);
 
-      const doc = parseHtml(this.normalizeXfaXml(xmlString), { script: true });
+      const doc = parseHtml(xmlString, { script: true });
 
       for (const script of this.collectXFAScripts(doc)) {
         const scriptContent = script.scriptNode.text?.trim();
@@ -1255,8 +1228,7 @@ export default class PDFDocument {
       );
     }
 
-    const normalizedXml = this.normalizeXfaXml(xmlString);
-    const doc = parseHtml(normalizedXml, { script: true });
+    const doc = parseHtml(xmlString, { script: true });
 
     const entries = this.collectXFAScripts(doc).filter(
       (e) => e.field === fieldName && e.event === eventName,
@@ -1269,40 +1241,10 @@ export default class PDFDocument {
       );
     }
 
-    // Replace every matching <script> node rather than only the first one.
-    // Work through the entries in document order and consume one occurrence of
-    // each node's serialized form per iteration, so duplicated script bodies
-    // for the same (field, event) are each updated exactly once instead of the
-    // first occurrence being overwritten repeatedly.
-    //
-    // Note: this still relies on the parser's `outerHTML` matching the source
-    // bytes. If two logically-distinct scripts serialize identically and appear
-    // out of document order the mapping is ambiguous; such XFA templates are not
-    // supported. When the serialized form cannot be located at all abort instead
-    // of silently returning an unchanged document.
-    let updatedXml = normalizedXml;
     for (const entry of entries) {
-      const oldOuter = entry.scriptNode.outerHTML;
-      const tagOpen = oldOuter.match(/^(<script[^>]*>)/i)?.[1] ?? '<script>';
-      const newOuter = `${tagOpen}${this.escapeXML(newScript)}</script>`;
-
-      const index = updatedXml.indexOf(oldOuter);
-      if (index === -1) {
-        throw new Error(
-          `Unable to locate the serialized <script> for field "${fieldName}" ` +
-            `and event "${eventName}" in the XFA template. The parsed ` +
-            'representation does not match the source bytes, so the update was ' +
-            'aborted to avoid corrupting the document.',
-        );
-      }
-
-      updatedXml =
-        updatedXml.slice(0, index) +
-        newOuter +
-        updatedXml.slice(index + oldOuter.length);
+      entry.scriptNode.set_content(this.escapeXML(newScript));
     }
-
-    updatedXml = updatedXml.replace(/xfa-template/g, 'template');
+    const updatedXml = doc.toString();
 
     const newXmlBytes = new TextEncoder().encode(updatedXml);
     const filter = templateInfo.stream.dict.get(PDFName.of('Filter'));

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -8,7 +8,7 @@ export enum ParseSpeeds {
   Slow = 100,
 }
 
-export interface AttachmentOptions extends EmbeddedFileOptions {}
+export interface AttachmentOptions extends EmbeddedFileOptions { }
 
 export interface SaveOptions {
   useObjectStreams?: boolean;
@@ -36,6 +36,7 @@ export interface LoadOptions {
   capNumbers?: boolean;
   password?: string;
   forIncrementalUpdate?: boolean;
+  preserveXFA?: boolean;
 }
 
 export interface CreateOptions {

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -8,7 +8,7 @@ export enum ParseSpeeds {
   Slow = 100,
 }
 
-export interface AttachmentOptions extends EmbeddedFileOptions { }
+export interface AttachmentOptions extends EmbeddedFileOptions {}
 
 export interface SaveOptions {
   useObjectStreams?: boolean;

--- a/src/api/PDFJavaScriptAction.ts
+++ b/src/api/PDFJavaScriptAction.ts
@@ -1,0 +1,133 @@
+import PDFDocument from './PDFDocument';
+import { PDFDict, PDFName, PDFString, PDFHexString, PDFRef } from '../core';
+
+/**
+ * Represents a JavaScript action extracted from a PDF.
+ * JavaScript actions can be attached to documents, pages, fields, and annotations.
+ */
+export default class PDFJavaScriptAction {
+  /** The underlying dictionary for this JavaScript action. */
+  readonly dict: PDFDict;
+
+  /** The document to which this action belongs. */
+  readonly doc: PDFDocument;
+
+  /** The reference to this action (if any). */
+  readonly ref?: PDFRef;
+
+  private constructor(dict: PDFDict, doc: PDFDocument, ref?: PDFRef) {
+    this.dict = dict;
+    this.doc = doc;
+    this.ref = ref;
+  }
+
+  /**
+   * Create a PDFJavaScriptAction from a dictionary.
+   * @param dict The action dictionary
+   * @param doc The document to which this action belongs
+   * @param ref The reference to this action (if any)
+   * @returns A PDFJavaScriptAction instance or undefined if not a JavaScript action
+   */
+  static of(
+    dict: PDFDict,
+    doc: PDFDocument,
+    ref?: PDFRef,
+  ): PDFJavaScriptAction | undefined {
+    const s = dict.lookup(PDFName.of('S'));
+    if (s instanceof PDFName && s.asString() === '/JavaScript') {
+      return new PDFJavaScriptAction(dict, doc, ref);
+    }
+    return undefined;
+  }
+
+  /**
+   * Get the JavaScript code from this action.
+   * @returns The JavaScript code as a string
+   */
+  getScript(): string | undefined {
+    const js = this.dict.lookup(PDFName.of('JS'));
+    if (js instanceof PDFString) {
+      return js.asString();
+    }
+    if (js instanceof PDFHexString) {
+      return js.decodeText();
+    }
+    return undefined;
+  }
+
+  /**
+   * Set the JavaScript code for this action.
+   * @param script The JavaScript code to set
+   */
+  setScript(script: string): void {
+    this.dict.set(PDFName.of('JS'), PDFHexString.fromText(script));
+  }
+}
+
+export interface JavaScriptActionMap {
+  /** Keystroke action (K) - executed when the user types in a field */
+  keystroke?: PDFJavaScriptAction;
+  /** Format action (F) - executed to format the field's value */
+  format?: PDFJavaScriptAction;
+  /** Validate action (V) - executed to validate the field's value */
+  validate?: PDFJavaScriptAction;
+  /** Calculate action (C) - executed to recalculate the field's value */
+  calculate?: PDFJavaScriptAction;
+  /** Mouse up action (U) - executed when mouse button is released */
+  mouseUp?: PDFJavaScriptAction;
+  /** Mouse down action (D) - executed when mouse button is pressed */
+  mouseDown?: PDFJavaScriptAction;
+  /** Mouse enter action (E) - executed when cursor enters annotation area */
+  mouseEnter?: PDFJavaScriptAction;
+  /** Mouse exit action (X) - executed when cursor exits annotation area */
+  mouseExit?: PDFJavaScriptAction;
+  /** Page open action (O) - executed when page is opened */
+  pageOpen?: PDFJavaScriptAction;
+  /** Page close action (C) - executed when page is closed */
+  pageClose?: PDFJavaScriptAction;
+  /** Focus action (Fo) - executed when annotation receives focus */
+  focus?: PDFJavaScriptAction;
+  /** Blur action (Bl) - executed when annotation loses focus */
+  blur?: PDFJavaScriptAction;
+}
+
+/**
+ * Extract JavaScript actions from an Additional Actions (AA) dictionary.
+ * @param aaDict The AA dictionary
+ * @param doc The document
+ * @returns A map of JavaScript actions
+ */
+export function extractAdditionalActions(
+  aaDict: PDFDict,
+  doc: PDFDocument,
+): JavaScriptActionMap {
+  const actions: JavaScriptActionMap = {};
+
+  const actionKeys = [
+    { key: 'K', prop: 'keystroke' as const },
+    { key: 'F', prop: 'format' as const },
+    { key: 'V', prop: 'validate' as const },
+    { key: 'C', prop: 'calculate' as const },
+    { key: 'U', prop: 'mouseUp' as const },
+    { key: 'D', prop: 'mouseDown' as const },
+    { key: 'E', prop: 'mouseEnter' as const },
+    { key: 'X', prop: 'mouseExit' as const },
+    { key: 'O', prop: 'pageOpen' as const },
+    { key: 'Fo', prop: 'focus' as const },
+    { key: 'Bl', prop: 'blur' as const },
+  ];
+
+  for (const { key, prop } of actionKeys) {
+    const actionObj = aaDict.get(PDFName.of(key));
+    if (actionObj instanceof PDFRef) {
+      const actionDict = aaDict.context.lookup(actionObj, PDFDict);
+      const action = PDFJavaScriptAction.of(actionDict, doc, actionObj);
+      if (action) actions[prop] = action;
+    } else if (actionObj instanceof PDFDict) {
+      const action = PDFJavaScriptAction.of(actionObj, doc);
+      if (action) actions[prop] = action;
+    }
+  }
+
+  return actions;
+}

--- a/src/api/PDFJavaScriptAction.ts
+++ b/src/api/PDFJavaScriptAction.ts
@@ -75,17 +75,7 @@ export default class PDFJavaScriptAction {
       return jsValue.decodeText();
     }
     if (jsValue instanceof PDFName) {
-      // Handle case where the value was created with context.obj() using a string literal
-      // PDFName.asString() returns the encoded name with leading slash and hex-encoded special chars
-      // We need to remove the slash and decode the hex sequences
-      const nameStr = jsValue.asString();
-      const withoutSlash = nameStr.startsWith('/')
-        ? nameStr.substring(1)
-        : nameStr;
-      // Decode hex sequences like #28 -> (
-      return withoutSlash.replace(/#([\dA-Fa-f]{2})/g, (_, hex) =>
-        String.fromCharCode(parseInt(hex, 16)),
-      );
+      return jsValue.decodeText();
     }
     return undefined;
   }

--- a/src/api/PDFJavaScriptAction.ts
+++ b/src/api/PDFJavaScriptAction.ts
@@ -1,5 +1,14 @@
 import PDFDocument from './PDFDocument';
-import { PDFDict, PDFName, PDFString, PDFHexString, PDFRef } from '../core';
+import {
+  PDFDict,
+  PDFName,
+  PDFString,
+  PDFHexString,
+  PDFRef,
+  PDFStream,
+  PDFRawStream,
+  decodePDFRawStream,
+} from '../core';
 
 /**
  * Represents a JavaScript action extracted from a PDF.
@@ -77,6 +86,16 @@ export default class PDFJavaScriptAction {
     if (jsValue instanceof PDFName) {
       return jsValue.decodeText();
     }
+
+    const jsRaw = js instanceof PDFRef ? this.dict.context.lookup(js) : js;
+    if (jsRaw instanceof PDFStream) {
+      const bytes =
+        jsRaw instanceof PDFRawStream
+          ? decodePDFRawStream(jsRaw).decode()
+          : jsRaw.getContents();
+      return new TextDecoder('utf-8').decode(bytes);
+    }
+
     return undefined;
   }
 

--- a/src/api/PDFJavaScriptAction.ts
+++ b/src/api/PDFJavaScriptAction.ts
@@ -117,31 +117,72 @@ export interface JavaScriptActionMap {
 }
 
 /**
+ * The `AA` (additional-actions) key `C` is context-sensitive in the PDF spec:
+ * in a field dictionary it is the *calculate* action, while in a page
+ * dictionary it is the *page close* action. Because a single `C` entry can
+ * only mean one of these, the extractor must be told which context it is
+ * reading so the same entry is not surfaced as both `calculate` and
+ * `pageClose`.
+ */
+export type AdditionalActionsContext = 'field' | 'page';
+
+/** Field-level additional actions (PDF spec table 197). */
+const FIELD_ACTION_KEYS = [
+  { key: 'K', prop: 'keystroke' as const },
+  { key: 'F', prop: 'format' as const },
+  { key: 'V', prop: 'validate' as const },
+  { key: 'C', prop: 'calculate' as const },
+  { key: 'U', prop: 'mouseUp' as const },
+  { key: 'D', prop: 'mouseDown' as const },
+  { key: 'E', prop: 'mouseEnter' as const },
+  { key: 'X', prop: 'mouseExit' as const },
+  { key: 'Fo', prop: 'focus' as const },
+  { key: 'Bl', prop: 'blur' as const },
+];
+
+/** Page-level additional actions (PDF spec table 196). */
+const PAGE_ACTION_KEYS = [
+  { key: 'O', prop: 'pageOpen' as const },
+  { key: 'C', prop: 'pageClose' as const },
+];
+
+/**
  * Extract JavaScript actions from an Additional Actions (AA) dictionary.
+ *
+ * The `context` argument disambiguates the shared `C` key: pass `'field'` when
+ * reading a form field's `AA` dictionary (so `C` maps to `calculate`) and
+ * `'page'` when reading a page's `AA` dictionary (so `C` maps to `pageClose`).
+ * When omitted, field semantics are used together with the unambiguous page
+ * `O` (pageOpen) key, preserving backwards-compatible behaviour without ever
+ * mapping a single `C` entry to two different actions.
+ *
  * @param aaDict The AA dictionary
  * @param doc The document
+ * @param context Whether the dictionary belongs to a field or a page
  * @returns A map of JavaScript actions
  */
 export function extractAdditionalActions(
   aaDict: PDFDict,
   doc: PDFDocument,
+  context?: AdditionalActionsContext,
 ): JavaScriptActionMap {
   const actions: JavaScriptActionMap = {};
 
-  const actionKeys = [
-    { key: 'K', prop: 'keystroke' as const },
-    { key: 'F', prop: 'format' as const },
-    { key: 'V', prop: 'validate' as const },
-    { key: 'C', prop: 'calculate' as const },
-    { key: 'U', prop: 'mouseUp' as const },
-    { key: 'D', prop: 'mouseDown' as const },
-    { key: 'E', prop: 'mouseEnter' as const },
-    { key: 'X', prop: 'mouseExit' as const },
-    { key: 'O', prop: 'pageOpen' as const },
-    { key: 'C', prop: 'pageClose' as const }, // Note: C is used for both calculate (fields) and pageClose (pages)
-    { key: 'Fo', prop: 'focus' as const },
-    { key: 'Bl', prop: 'blur' as const },
-  ];
+  let actionKeys: Array<{ key: string; prop: keyof JavaScriptActionMap }>;
+  switch (context) {
+    case 'page':
+      actionKeys = PAGE_ACTION_KEYS;
+      break;
+    case 'field':
+      actionKeys = FIELD_ACTION_KEYS;
+      break;
+    default:
+      // field actions plus the unambiguous page-open key. `C` resolves to `calculate`
+      actionKeys = [
+        ...FIELD_ACTION_KEYS,
+        { key: 'O', prop: 'pageOpen' as const },
+      ];
+  }
 
   for (const { key, prop } of actionKeys) {
     const actionObj = aaDict.get(PDFName.of(key));

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -739,7 +739,7 @@ export default class PDFPage {
       return undefined;
     }
 
-    return extractAdditionalActions(actualDict, this.doc);
+    return extractAdditionalActions(actualDict, this.doc, 'page');
   }
 
   /**

--- a/src/api/form/PDFField.ts
+++ b/src/api/form/PDFField.ts
@@ -26,6 +26,10 @@ import { assertIs, assertMultiple, assertOrUndefined } from '../../utils';
 import { ImageAlignment } from '../image';
 import PDFImage from '../PDFImage';
 import { drawImage, rotateInPlace } from '../operations';
+import PDFJavaScriptAction, {
+  JavaScriptActionMap,
+  extractAdditionalActions,
+} from '../PDFJavaScriptAction';
 
 export interface FieldAppearanceOptions {
   x?: number;
@@ -246,6 +250,61 @@ export default class PDFField {
    */
   disableExporting() {
     this.acroField.setFlagTo(AcroFieldFlags.NoExport, true);
+  }
+
+  /**
+   * Get the JavaScript actions associated with this field.
+   * Returns a map of action types to JavaScript actions.
+   * For example:
+   * ```js
+   * const field = form.getField('some.field')
+   * const actions = field.getJavaScriptActions()
+   * if (actions.keystroke) {
+   *   console.log('Keystroke script:', actions.keystroke.getScript())
+   * }
+   * if (actions.calculate) {
+   *   console.log('Calculate script:', actions.calculate.getScript())
+   * }
+   * ```
+   * @returns A map of JavaScript actions for this field, or undefined if none exist.
+   */
+  getJavaScriptActions(): JavaScriptActionMap | undefined {
+    const aaDict = this.acroField.dict.lookup(PDFName.of('AA'), PDFDict);
+    if (!aaDict) return undefined;
+    return extractAdditionalActions(aaDict, this.doc);
+  }
+
+  /**
+   * Get the default action (A) for this field.
+   * This is typically a submit or reset action, or can be a JavaScript action.
+   * For example:
+   * ```js
+   * const field = form.getField('some.field')
+   * const action = field.getAction()
+   * if (action) {
+   *   console.log('Action script:', action.getScript())
+   * }
+   * ```
+   * @returns The JavaScript action, or undefined if not a JavaScript action.
+   */
+  getAction(): PDFJavaScriptAction | undefined {
+    const actionObj = this.acroField.dict.get(PDFName.of('A'));
+    if (!actionObj) return undefined;
+
+    let actionDict: PDFDict;
+    if (actionObj instanceof PDFRef) {
+      actionDict = this.acroField.dict.context.lookup(actionObj, PDFDict);
+    } else if (actionObj instanceof PDFDict) {
+      actionDict = actionObj;
+    } else {
+      return undefined;
+    }
+
+    return PDFJavaScriptAction.of(
+      actionDict,
+      this.doc,
+      actionObj instanceof PDFRef ? actionObj : undefined,
+    );
   }
 
   /** @ignore */

--- a/src/api/form/PDFField.ts
+++ b/src/api/form/PDFField.ts
@@ -269,8 +269,18 @@ export default class PDFField {
    * @returns A map of JavaScript actions for this field, or undefined if none exist.
    */
   getJavaScriptActions(): JavaScriptActionMap | undefined {
-    const aaDict = this.acroField.dict.lookup(PDFName.of('AA'), PDFDict);
-    if (!aaDict) return undefined;
+    const aaEntry = this.acroField.dict.get(PDFName.of('AA'));
+    if (!aaEntry) return undefined;
+
+    let aaDict: PDFDict;
+    if (aaEntry instanceof PDFRef) {
+      aaDict = this.doc.context.lookup(aaEntry, PDFDict);
+    } else if (aaEntry instanceof PDFDict) {
+      aaDict = aaEntry;
+    } else {
+      return undefined;
+    }
+
     return extractAdditionalActions(aaDict, this.doc);
   }
 

--- a/src/api/form/PDFField.ts
+++ b/src/api/form/PDFField.ts
@@ -281,7 +281,7 @@ export default class PDFField {
       return undefined;
     }
 
-    return extractAdditionalActions(aaDict, this.doc);
+    return extractAdditionalActions(aaDict, this.doc, 'field');
   }
 
   /**

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -60,7 +60,7 @@ export interface FlattenOptions {
 /**
  * Describes a signature field declared inside an XFA form template.
  */
-export interface XFASignature {
+export interface XFASignatureField {
   field: string;
   manifest: string | null;
   refs: string[];
@@ -70,7 +70,7 @@ export interface XFASignature {
  * Describes a signature field found in a [[PDFDocument]], regardless of whether
  * it is declared in the AcroForm `/Fields` array or inside an XFA template.
  */
-export interface SignatureFieldInfo {
+export interface SignatureField {
   name: string;
   source: 'acroform' | 'xfa';
   acroField?: PDFSignature;
@@ -358,8 +358,8 @@ export default class PDFForm {
    *
    * @returns An array of [[XFASignature]] objects, one per XFA signature field.
    */
-  getXFASignatures(): XFASignature[] {
-    const result: XFASignature[] = [];
+  getXFASignatures(): XFASignatureField[] {
+    const result: XFASignatureField[] = [];
 
     if (!this.hasXFA()) return result;
 
@@ -367,7 +367,7 @@ export default class PDFForm {
     if (xmlString === null) return result;
 
     try {
-      const doc = parseHtml(this.normalizeXFATemplate(xmlString), {
+      const doc = parseHtml(xmlString, {
         script: true,
       });
 
@@ -415,8 +415,8 @@ export default class PDFForm {
    * @returns An array of [[SignatureFieldInfo]] describing every signature
    *          field, whether it originates from the AcroForm or from XFA.
    */
-  getSignatureFields(): SignatureFieldInfo[] {
-    const results: SignatureFieldInfo[] = [];
+  getSignatureFields(): SignatureField[] {
+    const results: SignatureField[] = [];
 
     for (const field of this.getFields()) {
       if (field instanceof PDFSignature) {
@@ -478,19 +478,6 @@ export default class PDFForm {
     }
 
     return null;
-  }
-
-  /**
-   * Normalizes XFA template XML so that node-html-better-parser can parse it
-   * correctly. XFA uses `\n>` to close opening tags, and the HTML parser treats
-   * `<template>` as a special inert element, so both need to be worked around.
-   */
-  private normalizeXFATemplate(xml: string): string {
-    return xml
-      .replace(/\n>/g, '>')
-      .replace(/<template(\s)/g, '<xfa-template$1')
-      .replace(/<template>/g, '<xfa-template>')
-      .replace(/<\/template>/g, '</xfa-template>');
   }
 
   /**

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -34,17 +34,48 @@ import {
   PDFAcroText,
   PDFAcroPushButton,
   PDFAcroNonTerminal,
+  PDFArray,
   PDFDict,
+  PDFHexString,
   PDFOperator,
+  PDFRawStream,
   PDFRef,
+  PDFString,
   createPDFAcroFields,
+  decodePDFRawStream,
   PDFName,
   PDFWidgetAnnotation,
 } from '../../core';
-import { assertIs, Cache, assertOrUndefined } from '../../utils';
+import { assertIs, Cache, assertOrUndefined, decodeXfaXml } from '../../utils';
+import {
+  parse as parseHtml,
+  HTMLElement,
+  NodeType,
+} from 'node-html-better-parser';
 
 export interface FlattenOptions {
   updateFieldAppearances: boolean;
+}
+
+/**
+ * Describes a signature field declared inside an XFA form template.
+ */
+export interface XFASignature {
+  field: string;
+  manifest: string | null;
+  refs: string[];
+}
+
+/**
+ * Describes a signature field found in a [[PDFDocument]], regardless of whether
+ * it is declared in the AcroForm `/Fields` array or inside an XFA template.
+ */
+export interface SignatureFieldInfo {
+  name: string;
+  source: 'acroform' | 'xfa';
+  acroField?: PDFSignature;
+  manifest?: string | null;
+  refs?: string[];
 }
 
 /**
@@ -306,6 +337,228 @@ export default class PDFForm {
     const field = this.getField(name);
     if (field instanceof PDFSignature) return field;
     throw new UnexpectedFieldTypeError(name, PDFSignature, field);
+  }
+
+  /**
+   * Get the signature fields declared inside this form's XFA template (if any).
+   *
+   * Dynamic XFA forms declare signature fields inside the template XML rather
+   * than in the AcroForm `/Fields` array, so [[PDFForm.getSignature]] cannot
+   * see them. Each signature field carries a `<signature>` UI element that
+   * references a `<manifest>` describing which fields the signature covers (its
+   * FieldMDP scope). This method surfaces that information.
+   *
+   * For example:
+   * ```js
+   * const form = pdfDoc.getForm()
+   * form.getXFASignatures().forEach(({ field, manifest, refs }) => {
+   *   console.log(`Signature "${field}" (manifest ${manifest}) covers`, refs)
+   * })
+   * ```
+   *
+   * @returns An array of [[XFASignature]] objects, one per XFA signature field.
+   */
+  getXFASignatures(): XFASignature[] {
+    const result: XFASignature[] = [];
+
+    if (!this.hasXFA()) return result;
+
+    const xmlString = this.getXFATemplateXml();
+    if (xmlString === null) return result;
+
+    try {
+      const doc = parseHtml(this.normalizeXFATemplate(xmlString), {
+        script: true,
+      });
+
+      const signatures: Array<{
+        field: string;
+        manifestUse?: string;
+        inlineRefs: string[];
+      }> = [];
+      const manifests = new Map<string, string[]>();
+      this.collectXFASignatureData(doc, signatures, manifests);
+
+      for (const sig of signatures) {
+        let refs = sig.inlineRefs;
+        if (sig.manifestUse && manifests.has(sig.manifestUse)) {
+          refs = manifests.get(sig.manifestUse)!;
+        }
+        result.push({
+          field: sig.field,
+          manifest: sig.manifestUse ?? null,
+          refs,
+        });
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to parse XFA template: ${error.message}`);
+      }
+      throw error;
+    }
+
+    return result;
+  }
+
+  /**
+   * Get all signature fields in this form, including both AcroForm signature
+   * fields and signature fields declared inside an XFA template.
+   * For example:
+   * ```js
+   * const form = pdfDoc.getForm()
+   * const sigFields = form.getSignatureFields()
+   * sigFields.forEach(({ name, source }) => {
+   *   console.log(`${source} signature field: ${name}`)
+   * })
+   * ```
+   *
+   * @returns An array of [[SignatureFieldInfo]] describing every signature
+   *          field, whether it originates from the AcroForm or from XFA.
+   */
+  getSignatureFields(): SignatureFieldInfo[] {
+    const results: SignatureFieldInfo[] = [];
+
+    for (const field of this.getFields()) {
+      if (field instanceof PDFSignature) {
+        results.push({
+          name: field.getName(),
+          source: 'acroform',
+          acroField: field,
+        });
+      }
+    }
+
+    for (const xfaSig of this.getXFASignatures()) {
+      results.push({
+        name: xfaSig.field,
+        source: 'xfa',
+        manifest: xfaSig.manifest,
+        refs: xfaSig.refs,
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * Reads this form's XFA `template` packet and returns its decoded XML, or
+   * `null` if the form has no XFA data or no template packet. The XFA data
+   * lives in this form's AcroForm dictionary under `/XFA`, stored as an array
+   * of alternating name/stream pairs.
+   */
+  private getXFATemplateXml(): string | null {
+    const context = this.acroForm.dict.context;
+    const xfaObj = this.acroForm.dict.get(PDFName.of('XFA'));
+    if (!xfaObj) return null;
+
+    const xfa = xfaObj instanceof PDFRef ? context.lookup(xfaObj) : xfaObj;
+    if (!(xfa instanceof PDFArray)) return null;
+
+    for (let idx = 0; idx < xfa.size(); idx += 2) {
+      const nameObj = xfa.get(idx);
+      const streamObj = xfa.get(idx + 1);
+      if (!nameObj || !streamObj) continue;
+
+      let sectionName: string;
+      if (nameObj instanceof PDFString) {
+        sectionName = nameObj.asString();
+      } else if (nameObj instanceof PDFHexString) {
+        sectionName = nameObj.decodeText();
+      } else {
+        continue;
+      }
+      if (sectionName !== 'template') continue;
+
+      const stream =
+        streamObj instanceof PDFRef ? context.lookup(streamObj) : streamObj;
+      if (!(stream instanceof PDFRawStream)) continue;
+
+      const xmlBytes = decodePDFRawStream(stream).decode();
+      return decodeXfaXml(xmlBytes);
+    }
+
+    return null;
+  }
+
+  /**
+   * Normalizes XFA template XML so that node-html-better-parser can parse it
+   * correctly. XFA uses `\n>` to close opening tags, and the HTML parser treats
+   * `<template>` as a special inert element, so both need to be worked around.
+   */
+  private normalizeXFATemplate(xml: string): string {
+    return xml
+      .replace(/\n>/g, '>')
+      .replace(/<template(\s)/g, '<xfa-template$1')
+      .replace(/<template>/g, '<xfa-template>')
+      .replace(/<\/template>/g, '</xfa-template>');
+  }
+
+  /**
+   * Recursively walks the XFA template tree collecting signature fields (a
+   * `<field>` whose descendant is a `<signature>` element) together with every
+   * `<manifest>` definition keyed by its `id` so that a signature's
+   * `<manifest use="#id"/>` reference can be resolved to its `<ref>` list.
+   */
+  private collectXFASignatureData(
+    node: HTMLElement,
+    signatures: Array<{
+      field: string;
+      manifestUse?: string;
+      inlineRefs: string[];
+    }>,
+    manifests: Map<string, string[]>,
+    currentField?: string,
+  ): void {
+    const tag = node.tagName?.toLowerCase();
+    let fieldCtx = currentField;
+
+    if (tag === 'field') {
+      fieldCtx = node.getAttribute('name') ?? undefined;
+    } else if (tag === 'manifest') {
+      const id = node.getAttribute('id');
+      if (id) manifests.set(id, this.collectXFARefs(node));
+    } else if (tag === 'signature' && fieldCtx) {
+      let manifestUse: string | undefined;
+      const inlineRefs: string[] = [];
+      for (const child of node.childNodes) {
+        if (child.nodeType !== NodeType.ELEMENT_NODE) continue;
+        const el = child as HTMLElement;
+        if (el.tagName?.toLowerCase() !== 'manifest') continue;
+        const use = el.getAttribute('use');
+        if (use) manifestUse = use.replace(/^#/, '');
+        const id = el.getAttribute('id');
+        const refs = this.collectXFARefs(el);
+        if (id) manifests.set(id, refs);
+        inlineRefs.push(...refs);
+      }
+      signatures.push({ field: fieldCtx, manifestUse, inlineRefs });
+    }
+
+    for (const child of node.childNodes) {
+      if (child.nodeType === NodeType.ELEMENT_NODE) {
+        this.collectXFASignatureData(
+          child as HTMLElement,
+          signatures,
+          manifests,
+          fieldCtx,
+        );
+      }
+    }
+  }
+
+  /**
+   * Collects the trimmed text of every direct `<ref>` child of the given node.
+   */
+  private collectXFARefs(node: HTMLElement): string[] {
+    const refs: string[] = [];
+    for (const child of node.childNodes) {
+      if (child.nodeType !== NodeType.ELEMENT_NODE) continue;
+      const el = child as HTMLElement;
+      if (el.tagName?.toLowerCase() !== 'ref') continue;
+      const text = el.text?.trim();
+      if (text) refs.push(text);
+    }
+    return refs;
   }
 
   /**

--- a/src/api/form/index.ts
+++ b/src/api/form/index.ts
@@ -3,7 +3,7 @@ export { default as PDFButton } from './PDFButton';
 export { default as PDFCheckBox } from './PDFCheckBox';
 export { default as PDFDropdown } from './PDFDropdown';
 export { default as PDFField } from './PDFField';
-export { default as PDFForm } from './PDFForm';
+export { default as PDFForm, SignatureFieldInfo } from './PDFForm';
 export { default as PDFOptionList } from './PDFOptionList';
 export { default as PDFRadioGroup } from './PDFRadioGroup';
 export { default as PDFSignature } from './PDFSignature';

--- a/src/api/form/index.ts
+++ b/src/api/form/index.ts
@@ -3,7 +3,7 @@ export { default as PDFButton } from './PDFButton';
 export { default as PDFCheckBox } from './PDFCheckBox';
 export { default as PDFDropdown } from './PDFDropdown';
 export { default as PDFField } from './PDFField';
-export { default as PDFForm, SignatureFieldInfo } from './PDFForm';
+export { default as PDFForm } from './PDFForm';
 export { default as PDFOptionList } from './PDFOptionList';
 export { default as PDFRadioGroup } from './PDFRadioGroup';
 export { default as PDFSignature } from './PDFSignature';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,11 @@ export { default as PDFImage } from './PDFImage';
 export { default as PDFPage } from './PDFPage';
 export { default as PDFEmbeddedPage } from './PDFEmbeddedPage';
 export { default as PDFJavaScript } from './PDFJavaScript';
+export {
+  default as PDFJavaScriptAction,
+  JavaScriptActionMap,
+  extractAdditionalActions,
+} from './PDFJavaScriptAction';
 export { default as Embeddable } from './Embeddable';
 export { default as PDFSvg } from './PDFSvg';
 export * from './snapshot';

--- a/src/core/streams/FlateStream.ts
+++ b/src/core/streams/FlateStream.ts
@@ -272,7 +272,7 @@ class FlateStream extends DecodeStream {
     buffer = this.buffer;
     let limit = buffer ? buffer.length : 0;
     let pos = this.bufferLength;
-    // eslint-disable-next-line no-constant-condition
+
     while (true) {
       let code1 = this.getCode(litCodeTable);
       if (code1 < 256) {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -190,3 +190,17 @@ export const findLastMatch = (value: string, regex: RegExp) => {
   }
   return { match: lastMatch, pos: position };
 };
+
+/**
+ * Decode XFA template bytes into a string.
+ * XFA templates are almost always UTF-8,
+ * Some producers, emit other single-byte encodings, rather than
+ * failing fall back to latin1, which maps every byte to a code point
+ */
+export const decodeXfaXml = (bytes: Uint8Array): string => {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return new TextDecoder('latin1').decode(bytes);
+  }
+};

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -2041,4 +2041,87 @@ describe('PDFDocument', () => {
       await expect(noErrorFunc(1)).resolves.not.toThrowError();
     });
   });
+
+  describe('getDocumentJavaScripts() method', () => {
+    it('returns empty array when no JavaScript exists', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const scripts = pdfDoc.getDocumentJavaScripts();
+      expect(scripts).toEqual([]);
+    });
+
+    it('can extract document-level JavaScript', async () => {
+      const pdfDoc = await PDFDocument.create();
+      pdfDoc.addJavaScript('script1', 'console.println("Test 1");');
+      pdfDoc.addJavaScript('script2', 'console.println("Test 2");');
+
+      await pdfDoc.flush();
+
+      const scripts = pdfDoc.getDocumentJavaScripts();
+
+      expect(scripts).toHaveLength(2);
+      expect(scripts[0].name).toBe('script1');
+      expect(scripts[0].script).toBe('console.println("Test 1");');
+      expect(scripts[1].name).toBe('script2');
+      expect(scripts[1].script).toBe('console.println("Test 2");');
+    });
+
+    it('can extract JavaScript from loaded PDF', async () => {
+      const pdfDoc1 = await PDFDocument.create();
+      pdfDoc1.addJavaScript('test', 'console.show();');
+      const savedBytes = await pdfDoc1.save();
+
+      const pdfDoc2 = await PDFDocument.load(savedBytes);
+      const scripts = pdfDoc2.getDocumentJavaScripts();
+
+      expect(scripts).toHaveLength(1);
+      expect(scripts[0].name).toBe('test');
+      expect(scripts[0].script).toBe('console.show();');
+    });
+  });
+
+  describe('preserveXFA option', () => {
+    it('deletes XFA by default', async () => {
+      const pdfDoc1 = await PDFDocument.create();
+      const form = pdfDoc1.getForm();
+
+      // Manually add XFA data
+      form.acroForm.dict.set(
+        PDFName.of('XFA'),
+        PDFArray.withContext(pdfDoc1.context),
+      );
+
+      const savedBytes = await pdfDoc1.save();
+
+      // Load without preserveXFA
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const pdfDoc2 = await PDFDocument.load(savedBytes);
+      const form2 = pdfDoc2.getForm();
+
+      expect(form2.hasXFA()).toBe(false);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Removing XFA form data'),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('preserves XFA when preserveXFA is true', async () => {
+      const pdfDoc1 = await PDFDocument.create();
+      const form = pdfDoc1.getForm();
+
+      // Manually add XFA data
+      form.acroForm.dict.set(
+        PDFName.of('XFA'),
+        PDFArray.withContext(pdfDoc1.context),
+      );
+
+      const savedBytes = await pdfDoc1.save();
+
+      // Load with preserveXFA
+      const pdfDoc2 = await PDFDocument.load(savedBytes, { preserveXFA: true });
+      const form2 = pdfDoc2.getForm();
+
+      expect(form2.hasXFA()).toBe(true);
+    });
+  });
 });

--- a/tests/api/PDFDocumentXFA.spec.ts
+++ b/tests/api/PDFDocumentXFA.spec.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import { PDFDocument } from 'src/index';
+
+const toUint8Array = (buf: Buffer) => new Uint8Array(buf);
+
+describe('PDFDocument - XFA JavaScript', () => {
+  const xfaPdfPath = 'assets/pdfs/with_xfa_fields.pdf';
+
+  it('can extract XFA JavaScript from template', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const xfaScripts = pdfDoc.getXFAJavaScripts();
+
+    expect(xfaScripts).toBeInstanceOf(Array);
+    expect(xfaScripts.length).toBeGreaterThan(0);
+
+    // Check structure of returned scripts
+    xfaScripts.forEach((script) => {
+      expect(script).toHaveProperty('field');
+      expect(script).toHaveProperty('event');
+      expect(script).toHaveProperty('script');
+      expect(typeof script.field).toBe('string');
+      expect(typeof script.event).toBe('string');
+      expect(typeof script.script).toBe('string');
+    });
+
+    // Look for known checkbox fields
+    const checkbox = xfaScripts.find((s) => s.field === 'c1_01');
+
+    expect(checkbox).toBeDefined();
+    expect(checkbox!.event).toBe('event__mouseUp');
+    expect(checkbox!.script).toContain('getField');
+  });
+
+  it('returns empty array for non-XFA PDFs', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const xfaScripts = pdfDoc.getXFAJavaScripts();
+
+    expect(xfaScripts).toBeInstanceOf(Array);
+    expect(xfaScripts.length).toBe(0);
+  });
+
+  it('can modify XFA JavaScript', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const originalScripts = pdfDoc.getXFAJavaScripts();
+    const checkbox = originalScripts.find((s) => s.field === 'c1_01');
+
+    expect(checkbox).toBeDefined();
+
+    const newScript = 'console.println("Modified checkbox script");';
+    const result = pdfDoc.setXFAJavaScript('c1_01', checkbox!.event, newScript);
+
+    expect(result).toBe(true);
+
+    // Verify the modification
+    const modifiedScripts = pdfDoc.getXFAJavaScripts();
+    const modifiedCheckbox = modifiedScripts.find(
+      (s) =>
+        s.field === 'c1_01' && s.script.includes('Modified checkbox script'),
+    );
+
+    expect(modifiedCheckbox).toBeDefined();
+    expect(modifiedCheckbox!.script).toContain(newScript);
+  });
+
+  it('returns false when modifying non-existent field', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const result = pdfDoc.setXFAJavaScript(
+      'nonexistent',
+      'event__click',
+      'test',
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('preserves XFA structure after modification', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const originalCount = pdfDoc.getXFAJavaScripts().length;
+
+    pdfDoc.setXFAJavaScript('c1_01', 'event__mouseUp', 'test();');
+
+    const modifiedCount = pdfDoc.getXFAJavaScripts().length;
+
+    // Script count should remain the same
+    expect(modifiedCount).toBe(originalCount);
+  });
+
+  it('can save and reload PDF with modified XFA JavaScript', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const newScript = 'xfa.host.messageBox("Test modification");';
+    pdfDoc.setXFAJavaScript('c1_01', 'event__mouseUp', newScript);
+
+    const savedBytes = await pdfDoc.save();
+
+    // Reload and verify
+    const reloadedDoc = await PDFDocument.load(savedBytes, {
+      preserveXFA: true,
+    });
+    const scripts = reloadedDoc.getXFAJavaScripts();
+    const checkbox = scripts.find(
+      (s) => s.field === 'c1_01' && s.script.includes('Test modification'),
+    );
+
+    expect(checkbox).toBeDefined();
+    expect(checkbox!.script).toContain(newScript);
+  });
+
+  it('extracts scripts from multiple events on same field', async () => {
+    const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
+    const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    const xfaScripts = pdfDoc.getXFAJavaScripts();
+
+    // Group by field name
+    const fieldScripts = new Map<string, number>();
+    xfaScripts.forEach((script) => {
+      const count = fieldScripts.get(script.field) || 0;
+      fieldScripts.set(script.field, count + 1);
+    });
+
+    // Some fields may have multiple events (c1_01, c2_05, etc. have 2 event__mouseUp events)
+    const multiEventFields = Array.from(fieldScripts.entries()).filter(
+      ([_, count]) => count > 1,
+    );
+
+    expect(multiEventFields.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/api/PDFDocumentXFA.spec.ts
+++ b/tests/api/PDFDocumentXFA.spec.ts
@@ -51,9 +51,7 @@ describe('PDFDocument - XFA JavaScript', () => {
     expect(checkbox).toBeDefined();
 
     const newScript = 'console.println("Modified checkbox script");';
-    const result = pdfDoc.setXFAJavaScript('c1_01', checkbox!.event, newScript);
-
-    expect(result).toBe(true);
+    pdfDoc.setXFAJavaScript('c1_01', checkbox!.event, newScript);
 
     // Verify the modification
     const modifiedScripts = pdfDoc.getXFAJavaScripts();
@@ -66,17 +64,13 @@ describe('PDFDocument - XFA JavaScript', () => {
     expect(modifiedCheckbox!.script).toContain(newScript);
   });
 
-  it('returns false when modifying non-existent field', async () => {
+  it('throws when modifying non-existent field', async () => {
     const pdfBytes = toUint8Array(fs.readFileSync(xfaPdfPath));
     const pdfDoc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
 
-    const result = pdfDoc.setXFAJavaScript(
-      'nonexistent',
-      'event__click',
-      'test',
-    );
-
-    expect(result).toBe(false);
+    expect(() =>
+      pdfDoc.setXFAJavaScript('nonexistent', 'event__click', 'test'),
+    ).toThrow('Script not found for field "nonexistent"');
   });
 
   it('preserves XFA structure after modification', async () => {

--- a/tests/api/PDFDocumentXFA.spec.ts
+++ b/tests/api/PDFDocumentXFA.spec.ts
@@ -1,7 +1,87 @@
 import fs from 'fs';
 import { PDFDocument } from 'src/index';
+import { PDFString, PDFName } from 'src/core';
 
 const toUint8Array = (buf: Buffer) => new Uint8Array(buf);
+
+/**
+ * Build a minimal dynamic-XFA PDF whose template contains the provided XML.
+ * The XFA array uses a `PDFString` section name ("template"), matching what
+ * `getXFATemplateInfo` expects. The document is saved without object streams
+ * for deterministic round-trips.
+ */
+async function buildXFAPdf(templateXml: string): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+
+  const context = (doc as any).context;
+  const templateRef = context.register(context.stream(templateXml));
+
+  const xfaArray = context.obj([]);
+  xfaArray.push(PDFString.of('template'));
+  xfaArray.push(templateRef);
+
+  const acroForm = context.obj({});
+  acroForm.set(PDFName.of('Fields'), context.obj([]));
+  acroForm.set(PDFName.of('XFA'), xfaArray);
+  acroForm.set(PDFName.of('SigFlags'), context.obj(3));
+
+  const acroRef = context.register(acroForm);
+  (doc as any).catalog.set(PDFName.of('AcroForm'), acroRef);
+
+  return doc.save({ useObjectStreams: false });
+}
+
+/**
+ * XFA template with a single signature field whose `<signature>` references a
+ * sibling `<manifest>` (the ANAF "use + manifest id" style).
+ */
+const XFA_ONE_SIGNATURE = `<template xmlns="http://www.xfa.org/schema/template/3.0/">
+  <subform name="form1">
+    <manifest name="semnatura1" id="sig1-guid"><ref>form1.fieldA</ref><ref>form1.fieldB</ref></manifest>
+    <field name="SignatureField1"><ui><signature type="PDF1.6"><manifest use="#sig1-guid"/></signature></ui><bind match="none"/></field>
+  </subform>
+</template>`;
+
+/**
+ * XFA template with multiple signature fields, each referencing its own
+ * manifest, plus a non-signature field to ensure only signatures are returned.
+ */
+const XFA_MULTIPLE_SIGNATURES = `<template xmlns="http://www.xfa.org/schema/template/3.0/">
+  <subform name="form1">
+    <manifest name="semnatura1" id="sig1-guid"><ref>form1.fieldA</ref><ref>form1.fieldB</ref></manifest>
+    <manifest name="semnatura2" id="sig2-guid"><ref>form1.fieldC</ref></manifest>
+    <field name="PlainField"><ui><textEdit/></ui></field>
+    <field name="SignatureField1"><ui><signature type="PDF1.6"><manifest use="#sig1-guid"/></signature></ui><bind match="none"/></field>
+    <field name="SignatureField2"><ui><signature type="PDF1.6"><manifest use="#sig2-guid"/></signature></ui><bind match="none"/></field>
+  </subform>
+</template>`;
+
+/**
+ * Add an AcroForm signature field (FT /Sig) to a document and its first page.
+ * pdf-lib does not expose a helper for creating signature fields, so we build
+ * the field dictionary directly. Cryptographic signing is intentionally out of
+ * scope (that lives outside pdf-lib).
+ */
+function addSignatureField(doc: PDFDocument, name: string): void {
+  const context = (doc as any).context;
+  const page = doc.getPage(0);
+
+  const widget = context.obj({
+    Type: 'Annot',
+    Subtype: 'Widget',
+    FT: 'Sig',
+    T: PDFString.of(name),
+    Rect: [50, 50, 250, 100],
+    F: 4,
+  });
+  const ref = context.register(widget);
+
+  const form = doc.getForm();
+  form.acroForm.addField(ref);
+  form.acroForm.dict.set(PDFName.of('SigFlags'), context.obj(3));
+  page.node.addAnnot(ref);
+}
 
 describe('PDFDocument - XFA JavaScript', () => {
   const xfaPdfPath = 'assets/pdfs/with_xfa_fields.pdf';
@@ -128,5 +208,143 @@ describe('PDFDocument - XFA JavaScript', () => {
     );
 
     expect(multiEventFields.length).toBeGreaterThan(0);
+  });
+});
+
+describe('PDFDocument - XFA signature fields', () => {
+  it('detects a single XFA signature field with its manifest refs', async () => {
+    const bytes = await buildXFAPdf(XFA_ONE_SIGNATURE);
+    const doc = await PDFDocument.load(bytes, { preserveXFA: true });
+
+    const sigFields = doc.getForm().getXFASignatures();
+
+    expect(sigFields).toHaveLength(1);
+    expect(sigFields[0].field).toBe('SignatureField1');
+    expect(sigFields[0].manifest).toBe('sig1-guid');
+    expect(sigFields[0].refs).toEqual(['form1.fieldA', 'form1.fieldB']);
+  });
+
+  it('detects multiple XFA signature fields, ignoring non-signature fields', async () => {
+    const bytes = await buildXFAPdf(XFA_MULTIPLE_SIGNATURES);
+    const doc = await PDFDocument.load(bytes, { preserveXFA: true });
+
+    const sigFields = doc.getForm().getXFASignatures();
+
+    expect(sigFields).toHaveLength(2);
+    const names = sigFields.map((s) => s.field).sort();
+    expect(names).toEqual(['SignatureField1', 'SignatureField2']);
+
+    const first = sigFields.find((s) => s.field === 'SignatureField1');
+    const second = sigFields.find((s) => s.field === 'SignatureField2');
+    expect(first!.refs).toEqual(['form1.fieldA', 'form1.fieldB']);
+    expect(second!.refs).toEqual(['form1.fieldC']);
+  });
+
+  it('returns an empty array for XFA forms without signature fields', async () => {
+    const pdfBytes = toUint8Array(
+      fs.readFileSync('assets/pdfs/with_xfa_fields.pdf'),
+    );
+    const doc = await PDFDocument.load(pdfBytes, { preserveXFA: true });
+
+    expect(doc.getForm().getXFASignatures()).toEqual([]);
+  });
+
+  it('returns an empty array for non-XFA documents', async () => {
+    const doc = await PDFDocument.create();
+    expect(doc.getForm().getXFASignatures()).toEqual([]);
+  });
+
+  it('surfaces XFA signature fields through PDFForm.getSignatureFields()', async () => {
+    const bytes = await buildXFAPdf(XFA_MULTIPLE_SIGNATURES);
+    const doc = await PDFDocument.load(bytes, { preserveXFA: true });
+
+    const fields = doc.getForm().getSignatureFields();
+
+    expect(fields).toHaveLength(2);
+    fields.forEach((f) => {
+      expect(f.source).toBe('xfa');
+      expect(f.acroField).toBeUndefined();
+      expect(Array.isArray(f.refs)).toBe(true);
+    });
+    // No AcroForm signature fields exist in a pure XFA document.
+    expect(fields.filter((f) => f.source === 'acroform')).toHaveLength(0);
+  });
+
+  // Optional validation against a real (unshipped) XFA-with-signatures PDF,
+  // e.g. an ANAF smart form. Skipped unless XFA_SIG_SAMPLE_PDF points to a file.
+  const samplePath = process.env.XFA_SIG_SAMPLE_PDF;
+  const maybeIt = samplePath && fs.existsSync(samplePath) ? it : it.skip;
+  maybeIt('detects signature fields in a real XFA sample PDF', async () => {
+    const bytes = toUint8Array(fs.readFileSync(samplePath as string));
+    const doc = await PDFDocument.load(bytes, {
+      preserveXFA: true,
+      throwOnInvalidObject: false,
+    });
+
+    const sigFields = doc.getForm().getXFASignatures();
+    expect(sigFields.length).toBeGreaterThan(0);
+    sigFields.forEach((s) => {
+      expect(typeof s.field).toBe('string');
+      expect(s.field.length).toBeGreaterThan(0);
+      expect(Array.isArray(s.refs)).toBe(true);
+    });
+  });
+});
+
+describe('PDFDocument - AcroForm signature detection (normal PDFs)', () => {
+  it('detects an existing signature field in a normal PDF', async () => {
+    const bytes = toUint8Array(
+      fs.readFileSync('assets/pdfs/with_signature.pdf'),
+    );
+    const doc = await PDFDocument.load(bytes);
+    const form = doc.getForm();
+
+    const sigFields = form.getSignatureFields();
+    expect(sigFields).toHaveLength(1);
+    expect(sigFields[0].source).toBe('acroform');
+    expect(sigFields[0].name).toBe('Signature1');
+    expect(sigFields[0].acroField).toBeDefined();
+  });
+
+  it('detects a signature field among many fields in a form PDF', async () => {
+    const bytes = toUint8Array(fs.readFileSync('assets/pdfs/sample_form.pdf'));
+    const doc = await PDFDocument.load(bytes);
+    const form = doc.getForm();
+
+    const sigFields = form.getSignatureFields();
+    expect(sigFields.length).toBeGreaterThanOrEqual(1);
+    expect(sigFields.some((s) => s.name === 'EMPLOYEE SIGNATURE')).toBe(true);
+  });
+
+  it('reports no signatures for a normal PDF that has none', async () => {
+    const bytes = toUint8Array(fs.readFileSync('assets/pdfs/normal.pdf'));
+    const doc = await PDFDocument.load(bytes);
+    const form = doc.getForm();
+
+    expect(form.getSignatureFields()).toHaveLength(0);
+  });
+
+  it('adds a signature field to a normal PDF and detects it after reload', async () => {
+    const bytes = toUint8Array(fs.readFileSync('assets/pdfs/normal.pdf'));
+    const doc = await PDFDocument.load(bytes);
+
+    expect(doc.getForm().getSignatureFields()).toHaveLength(0);
+
+    addSignatureField(doc, 'Signature1');
+
+    // Detected in-memory.
+    const inMemory = doc.getForm().getSignatureFields();
+    expect(inMemory).toHaveLength(1);
+    expect(inMemory[0].name).toBe('Signature1');
+
+    // Survives a save/reload round-trip.
+    const saved = await doc.save();
+    const reloaded = await PDFDocument.load(saved);
+    const form = reloaded.getForm();
+
+    const sigFields = form.getSignatureFields();
+    expect(sigFields).toHaveLength(1);
+    expect(sigFields[0].source).toBe('acroform');
+    expect(sigFields[0].name).toBe('Signature1');
   });
 });

--- a/tests/api/PDFJavaScriptAction.spec.ts
+++ b/tests/api/PDFJavaScriptAction.spec.ts
@@ -1,0 +1,291 @@
+import { PDFHexString, PDFString } from '../../src/core';
+import PDFDocument from '../../src/api/PDFDocument';
+import PDFJavaScriptAction, {
+  extractAdditionalActions,
+} from '../../src/api/PDFJavaScriptAction';
+
+describe('PDFJavaScriptAction', () => {
+  it('can be created from a JavaScript action dictionary', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const actionDict = context.obj({
+      Type: 'Action',
+      S: 'JavaScript',
+      JS: PDFHexString.fromText('console.println("Hello");'),
+    });
+
+    const ref = context.register(actionDict);
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc, ref);
+
+    expect(action).toBeInstanceOf(PDFJavaScriptAction);
+    expect(action?.dict).toBe(actionDict);
+    expect(action?.doc).toBe(pdfDoc);
+    expect(action?.ref).toBe(ref);
+  });
+
+  it('returns undefined for non-JavaScript actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const actionDict = context.obj({
+      Type: 'Action',
+      S: 'SubmitForm',
+      F: 'http://example.com/submit',
+    });
+
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc);
+
+    expect(action).toBeUndefined();
+  });
+
+  it('can get script from PDFString', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const script = 'console.println("Test");';
+    const actionDict = context.obj({
+      S: 'JavaScript',
+      JS: PDFString.of(script),
+    });
+
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc);
+    expect(action?.getScript()).toBe(script);
+  });
+
+  it('can get script from PDFHexString', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const script = 'console.println("Test");';
+    const actionDict = context.obj({
+      S: 'JavaScript',
+      JS: PDFHexString.fromText(script),
+    });
+
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc);
+    expect(action?.getScript()).toBe(script);
+  });
+
+  it('can set script', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const actionDict = context.obj({
+      S: 'JavaScript',
+      JS: PDFString.of('old script'),
+    });
+
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc);
+    expect(action?.getScript()).toBe('old script');
+
+    action?.setScript('new script');
+    expect(action?.getScript()).toBe('new script');
+  });
+
+  it('returns undefined when JS field is missing', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const actionDict = context.obj({
+      S: 'JavaScript',
+    });
+
+    const action = PDFJavaScriptAction.of(actionDict, pdfDoc);
+    expect(action?.getScript()).toBeUndefined();
+  });
+});
+
+describe('extractAdditionalActions', () => {
+  it('can extract keystroke action', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      K: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('keystroke script'),
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.keystroke).toBeInstanceOf(PDFJavaScriptAction);
+    expect(actions.keystroke?.getScript()).toBe('keystroke script');
+  });
+
+  it('can extract format action', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      F: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('format script'),
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.format).toBeInstanceOf(PDFJavaScriptAction);
+    expect(actions.format?.getScript()).toBe('format script');
+  });
+
+  it('can extract validate action', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      V: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('validate script'),
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.validate).toBeInstanceOf(PDFJavaScriptAction);
+    expect(actions.validate?.getScript()).toBe('validate script');
+  });
+
+  it('can extract calculate action', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      C: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('calculate script'),
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.calculate).toBeInstanceOf(PDFJavaScriptAction);
+    expect(actions.calculate?.getScript()).toBe('calculate script');
+  });
+
+  it('can extract multiple actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      K: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('keystroke'),
+      }),
+      F: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('format'),
+      }),
+      V: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('validate'),
+      }),
+      C: context.obj({
+        S: 'JavaScript',
+        JS: PDFString.of('calculate'),
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.keystroke?.getScript()).toBe('keystroke');
+    expect(actions.format?.getScript()).toBe('format');
+    expect(actions.validate?.getScript()).toBe('validate');
+    expect(actions.calculate?.getScript()).toBe('calculate');
+  });
+
+  it('can extract actions from indirect references', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const actionDict = context.obj({
+      S: 'JavaScript',
+      JS: PDFString.of('referenced script'),
+    });
+    const actionRef = context.register(actionDict);
+
+    const aaDict = context.obj({
+      K: actionRef,
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.keystroke?.getScript()).toBe('referenced script');
+  });
+
+  it('can extract mouse actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      U: context.obj({ S: 'JavaScript', JS: PDFString.of('mouseUp') }),
+      D: context.obj({ S: 'JavaScript', JS: PDFString.of('mouseDown') }),
+      E: context.obj({ S: 'JavaScript', JS: PDFString.of('mouseEnter') }),
+      X: context.obj({ S: 'JavaScript', JS: PDFString.of('mouseExit') }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.mouseUp?.getScript()).toBe('mouseUp');
+    expect(actions.mouseDown?.getScript()).toBe('mouseDown');
+    expect(actions.mouseEnter?.getScript()).toBe('mouseEnter');
+    expect(actions.mouseExit?.getScript()).toBe('mouseExit');
+  });
+
+  it('can extract focus actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      Fo: context.obj({ S: 'JavaScript', JS: PDFString.of('focus') }),
+      Bl: context.obj({ S: 'JavaScript', JS: PDFString.of('blur') }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.focus?.getScript()).toBe('focus');
+    expect(actions.blur?.getScript()).toBe('blur');
+  });
+
+  it('can extract page actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      O: context.obj({ S: 'JavaScript', JS: PDFString.of('pageOpen') }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.pageOpen?.getScript()).toBe('pageOpen');
+  });
+
+  it('returns empty object when no actions exist', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({});
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(Object.keys(actions).length).toBe(0);
+  });
+
+  it('ignores non-JavaScript actions', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      K: context.obj({
+        S: 'SubmitForm',
+        F: 'http://example.com',
+      }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.keystroke).toBeUndefined();
+  });
+});

--- a/tests/api/PDFJavaScriptAction.spec.ts
+++ b/tests/api/PDFJavaScriptAction.spec.ts
@@ -262,6 +262,53 @@ describe('extractAdditionalActions', () => {
     expect(actions.pageOpen?.getScript()).toBe('pageOpen');
   });
 
+  it('maps C to pageClose in page context', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      O: context.obj({ S: 'JavaScript', JS: PDFString.of('pageOpen') }),
+      C: context.obj({ S: 'JavaScript', JS: PDFString.of('pageClose') }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc, 'page');
+
+    expect(actions.pageOpen?.getScript()).toBe('pageOpen');
+    expect(actions.pageClose?.getScript()).toBe('pageClose');
+    // In page context, C must not leak into the field-only `calculate` slot.
+    expect(actions.calculate).toBeUndefined();
+  });
+
+  it('maps C to calculate in field context', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      C: context.obj({ S: 'JavaScript', JS: PDFString.of('calculate') }),
+    });
+
+    const actions = extractAdditionalActions(aaDict, pdfDoc, 'field');
+
+    expect(actions.calculate?.getScript()).toBe('calculate');
+    // In field context, C must not leak into the page-only `pageClose` slot.
+    expect(actions.pageClose).toBeUndefined();
+  });
+
+  it('does not map a single C entry to both calculate and pageClose', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const context = pdfDoc.context;
+
+    const aaDict = context.obj({
+      C: context.obj({ S: 'JavaScript', JS: PDFString.of('script') }),
+    });
+
+    // Default (no context): C resolves to calculate only, never pageClose.
+    const actions = extractAdditionalActions(aaDict, pdfDoc);
+
+    expect(actions.calculate?.getScript()).toBe('script');
+    expect(actions.pageClose).toBeUndefined();
+  });
+
   it('returns empty object when no actions exist', async () => {
     const pdfDoc = await PDFDocument.create();
     const context = pdfDoc.context;

--- a/tests/api/PDFPage.spec.ts
+++ b/tests/api/PDFPage.spec.ts
@@ -186,4 +186,104 @@ describe('PDFDocument', () => {
     expect(key1).not.toEqual(key2);
     expect(page2.node.normalizedEntries().Font.keys()).toEqual([key1, key2]);
   });
+
+  describe('getJavaScriptActions() method', () => {
+    it('returns undefined when page has no JavaScript actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const page = pdfDoc.addPage();
+
+      const actions = page.getJavaScriptActions();
+      expect(actions).toBeUndefined();
+    });
+
+    it('can extract page open action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const page = pdfDoc.addPage();
+      const context = pdfDoc.context;
+
+      // Manually add AA dictionary with page open action
+      const aaDict = context.obj({
+        O: context.obj({
+          S: 'JavaScript',
+          JS: 'console.println("Page opened");',
+        }),
+      });
+      page.node.set(PDFName.of('AA'), aaDict);
+
+      const actions = page.getJavaScriptActions();
+
+      expect(actions).toBeDefined();
+      expect(actions?.pageOpen).toBeDefined();
+      expect(actions?.pageOpen?.getScript()).toBe(
+        'console.println("Page opened");',
+      );
+    });
+
+    it('can extract page close action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const page = pdfDoc.addPage();
+      const context = pdfDoc.context;
+
+      // Manually add AA dictionary with page close action
+      const aaDict = context.obj({
+        C: context.obj({
+          S: 'JavaScript',
+          JS: 'console.println("Page closed");',
+        }),
+      });
+      page.node.set(PDFName.of('AA'), aaDict);
+
+      const actions = page.getJavaScriptActions();
+
+      expect(actions).toBeDefined();
+      expect(actions?.pageClose).toBeDefined();
+      expect(actions?.pageClose?.getScript()).toBe(
+        'console.println("Page closed");',
+      );
+    });
+
+    it('can extract multiple page actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const page = pdfDoc.addPage();
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        O: context.obj({
+          S: 'JavaScript',
+          JS: 'console.println("Opened");',
+        }),
+        C: context.obj({
+          S: 'JavaScript',
+          JS: 'console.println("Closed");',
+        }),
+      });
+      page.node.set(PDFName.of('AA'), aaDict);
+
+      const actions = page.getJavaScriptActions();
+
+      expect(actions?.pageOpen?.getScript()).toBe('console.println("Opened");');
+      expect(actions?.pageClose?.getScript()).toBe(
+        'console.println("Closed");',
+      );
+    });
+
+    it('handles AA as indirect reference', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const page = pdfDoc.addPage();
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        O: context.obj({
+          S: 'JavaScript',
+          JS: 'console.println("Test");',
+        }),
+      });
+      const aaRef = context.register(aaDict);
+      page.node.set(PDFName.of('AA'), aaRef);
+
+      const actions = page.getJavaScriptActions();
+
+      expect(actions?.pageOpen?.getScript()).toBe('console.println("Test");');
+    });
+  });
 });

--- a/tests/api/form/PDFFieldJavaScript.spec.ts
+++ b/tests/api/form/PDFFieldJavaScript.spec.ts
@@ -1,0 +1,294 @@
+import { PDFDocument, PDFName } from '../../../src/index';
+
+describe('PDFField JavaScript Actions', () => {
+  describe('getJavaScriptActions() method', () => {
+    it('returns undefined when field has no JavaScript actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+
+      const actions = field.getJavaScriptActions();
+      expect(actions).toBeUndefined();
+    });
+
+    it('can extract keystroke action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      // Manually add AA dictionary with keystroke action
+      const aaDict = context.obj({
+        K: context.obj({
+          S: 'JavaScript',
+          JS: 'event.change = event.change.toUpperCase();',
+        }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions).toBeDefined();
+      expect(actions?.keystroke).toBeDefined();
+      expect(actions?.keystroke?.getScript()).toBe(
+        'event.change = event.change.toUpperCase();',
+      );
+    });
+
+    it('can extract format action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        F: context.obj({
+          S: 'JavaScript',
+          JS: 'AFNumber_Format(2, 0, 0, 0, "$", true);',
+        }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.format).toBeDefined();
+      expect(actions?.format?.getScript()).toBe(
+        'AFNumber_Format(2, 0, 0, 0, "$", true);',
+      );
+    });
+
+    it('can extract validate action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        V: context.obj({
+          S: 'JavaScript',
+          JS: 'if (event.value < 0) event.rc = false;',
+        }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.validate).toBeDefined();
+      expect(actions?.validate?.getScript()).toBe(
+        'if (event.value < 0) event.rc = false;',
+      );
+    });
+
+    it('can extract calculate action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('total');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        C: context.obj({
+          S: 'JavaScript',
+          JS: 'var a = this.getField("price").value; var b = this.getField("quantity").value; event.value = a * b;',
+        }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.calculate).toBeDefined();
+      expect(actions?.calculate?.getScript()).toContain('event.value = a * b');
+    });
+
+    it('can extract multiple actions from same field', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        K: context.obj({
+          S: 'JavaScript',
+          JS: 'keystroke script',
+        }),
+        F: context.obj({
+          S: 'JavaScript',
+          JS: 'format script',
+        }),
+        V: context.obj({
+          S: 'JavaScript',
+          JS: 'validate script',
+        }),
+        C: context.obj({
+          S: 'JavaScript',
+          JS: 'calculate script',
+        }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.keystroke?.getScript()).toBe('keystroke script');
+      expect(actions?.format?.getScript()).toBe('format script');
+      expect(actions?.validate?.getScript()).toBe('validate script');
+      expect(actions?.calculate?.getScript()).toBe('calculate script');
+    });
+
+    it('can extract mouse actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        U: context.obj({ S: 'JavaScript', JS: 'mouseUp' }),
+        D: context.obj({ S: 'JavaScript', JS: 'mouseDown' }),
+        E: context.obj({ S: 'JavaScript', JS: 'mouseEnter' }),
+        X: context.obj({ S: 'JavaScript', JS: 'mouseExit' }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.mouseUp?.getScript()).toBe('mouseUp');
+      expect(actions?.mouseDown?.getScript()).toBe('mouseDown');
+      expect(actions?.mouseEnter?.getScript()).toBe('mouseEnter');
+      expect(actions?.mouseExit?.getScript()).toBe('mouseExit');
+    });
+
+    it('can extract focus actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const aaDict = context.obj({
+        Fo: context.obj({ S: 'JavaScript', JS: 'focus script' }),
+        Bl: context.obj({ S: 'JavaScript', JS: 'blur script' }),
+      });
+      field.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      const actions = field.getJavaScriptActions();
+
+      expect(actions?.focus?.getScript()).toBe('focus script');
+      expect(actions?.blur?.getScript()).toBe('blur script');
+    });
+  });
+
+  describe('getAction() method', () => {
+    it('returns undefined when field has no default action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+
+      const action = field.getAction();
+      expect(action).toBeUndefined();
+    });
+
+    it('can extract default JavaScript action', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const actionDict = context.obj({
+        S: 'JavaScript',
+        JS: 'console.println("Default action");',
+      });
+      field.acroField.dict.set(PDFName.of('A'), actionDict);
+
+      const action = field.getAction();
+
+      expect(action).toBeDefined();
+      expect(action?.getScript()).toBe('console.println("Default action");');
+    });
+
+    it('returns undefined for non-JavaScript actions', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const actionDict = context.obj({
+        S: 'SubmitForm',
+        F: 'http://example.com/submit',
+      });
+      field.acroField.dict.set(PDFName.of('A'), actionDict);
+
+      const action = field.getAction();
+      expect(action).toBeUndefined();
+    });
+
+    it('handles action as indirect reference', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const field = form.createTextField('test');
+      const context = pdfDoc.context;
+
+      const actionDict = context.obj({
+        S: 'JavaScript',
+        JS: 'referenced action',
+      });
+      const actionRef = context.register(actionDict);
+      field.acroField.dict.set(PDFName.of('A'), actionRef);
+
+      const action = field.getAction();
+
+      expect(action?.getScript()).toBe('referenced action');
+    });
+  });
+
+  describe('Integration test - field with multiple scripts', () => {
+    it('can extract all scripts from a complex form field', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const form = pdfDoc.getForm();
+      const taxField = form.createTextField('tax');
+      const context = pdfDoc.context;
+
+      // Add AA dictionary with multiple actions
+      const aaDict = context.obj({
+        K: context.obj({
+          S: 'JavaScript',
+          JS: 'if (event.willCommit) { event.value = event.value.replace(/[^0-9.]/g, ""); }',
+        }),
+        F: context.obj({
+          S: 'JavaScript',
+          JS: 'AFNumber_Format(2, 0, 0, 0, "$", true);',
+        }),
+        V: context.obj({
+          S: 'JavaScript',
+          JS: 'if (event.value < 0 || event.value > 100) { app.alert("Invalid tax amount"); event.rc = false; }',
+        }),
+        C: context.obj({
+          S: 'JavaScript',
+          JS: 'var subtotal = this.getField("subtotal").value; event.value = subtotal * 0.08;',
+        }),
+      });
+      taxField.acroField.dict.set(PDFName.of('AA'), aaDict);
+
+      // Add default action
+      const defaultAction = context.obj({
+        S: 'JavaScript',
+        JS: 'console.println("Field changed");',
+      });
+      taxField.acroField.dict.set(PDFName.of('A'), defaultAction);
+
+      const actions = taxField.getJavaScriptActions();
+      const action = taxField.getAction();
+
+      // Verify all scripts are extracted
+      expect(actions).toBeDefined();
+      expect(actions?.keystroke).toBeDefined();
+      expect(actions?.format).toBeDefined();
+      expect(actions?.validate).toBeDefined();
+      expect(actions?.calculate).toBeDefined();
+      expect(action).toBeDefined();
+
+      // Verify script content
+      expect(actions?.keystroke?.getScript()).toContain('event.value.replace');
+      expect(actions?.format?.getScript()).toContain('AFNumber_Format');
+      expect(actions?.validate?.getScript()).toContain('app.alert');
+      expect(actions?.calculate?.getScript()).toContain('subtotal * 0.08');
+      expect(action?.getScript()).toBe('console.println("Field changed");');
+    });
+  });
+});


### PR DESCRIPTION
## What?
First attempt at adding support for preserving XFA (XML Forms) forms and extracting/modifying JavaScript embedded in XFA templates.

## Why?
pdf-lib strips by default XFA data when loading and saving PDFs, causing these forms to lose all functionality. Additionally, there was no way to programmatically access or modify the JavaScript code embedded in XFA templates

## How?
1. **Preserv  XFA forms **
   - Added `preserveXFA` option to `PDFDocument.load()` and `PDFDocument.save()`
   - When enabled, preserves the entire XFA array structure from the AcroForm dictionary
   - Prevents XFA data loss during PDF modification

2. **XFA JavaScript Extraction (`getXFAJavaScripts()`)**
   - New method that extracts all JavaScript from XFA template XML
   - Parses compressed PDF streams and XML structure
   - Returns array of `{field: string, event: string, script: string}` objects
   - Handles XFA's non-standard XML formatting (newlines in closing tags like `</script\n>`)
   - Uses backward search to determine field and event context for each script

3. **XFA JavaScript Modification (`setXFAJavaScript(field, event, script)`)**
   - New method to modify specific scripts by field name and event name
   - Finds matching field/event in XML, replaces script content
   - Creates new compressed stream with modified XML
   - Returns boolean indicating success/failure
   - Preserves XFA structure and all other scripts

**Technical details:**
- XFA data is stored as alternating name/stream pairs in a PDFArray
- Template section contains the JavaScript in XML `<script>` elements
- Implemented special regex pattern to handle XFA's malformed XML (`<\/script\s*>` instead of `<\/script>`)
- Added PDFRef dereferencing for XFA array lookup
- Uses `decodePDFRawStream` to handle compressed streams

## Testing?

1. **Unit Tests (7 tests in `PDFDocumentXFA.spec.ts`)**
   - ✅ Extract XFA JavaScript from template (29 scripts from test PDF)
   - ✅ Returns empty array for non-XFA PDFs
   - ✅ Can modify XFA JavaScript
   - ✅ Returns false when modifying non-existent field
   - ✅ Preserves XFA structure after modification
   - ✅ Can save and reload PDF with modified XFA JavaScript
   - ✅ Extracts scripts from multiple events on same field
   - Uses `assets/pdfs/with_xfa_fields.pdf` (included in repo)

2. **Integration Testing**
   - Tested with my own complex pdf and the ready made one from the tests
   - Save/reload cycle preserves all modifications

## New Dependencies?
No new production dependencies. The implementation uses existing dependencies:
- `pako` (already in dependencies) - for stream compression/decompression
- All XFA functionality built using existing pdf-lib core modules

## Screenshots
-

## Suggested Reading?
- PDF 1.7 Specification Section 12.7.8 (Interactive Forms - XFA)
- Adobe XFA Specification 3.3
- AcroForm dictionary structure (Section 12.7.2)
- Stream encoding/compression (Section 7.3)

## Anything Else?
Documentation updates
