### PR TITLE
Fix in XrefStream generation process and size calculation

### DIFF
--- a/src/core/writers/PDFStreamWriter.ts
+++ b/src/core/writers/PDFStreamWriter.ts
@@ -92,7 +92,7 @@ class PDFStreamWriter extends PDFWriter {
     for (let idx = 0, len = indirectObjects.length; idx < len; idx++) {
       const indirectObject = indirectObjects[idx];
       const [ref, object] = indirectObject;
-      if (!this.snapshot.shouldSave(ref.objectNumber)) {
+      if (!this.shouldSave(incremental, ref.objectNumber, indirectObjects)) {
         continue;
       }
 

--- a/src/core/writers/PDFWriter.ts
+++ b/src/core/writers/PDFWriter.ts
@@ -87,8 +87,9 @@ class PDFWriter {
       // only the last XRef Stream will be regenerated on save
       if (!this._lastXRefObjectNumber) {
         // if no XRef Stream, then nothing should be skipped
-        this._lastXRefObjectNumber = this.context.largestObjectNumber + 1;
-        const checkWatermark = this._lastXRefObjectNumber - 10; // max number of objects in the final part of the PDF to check
+        // if we are adding a XRef Stream, then its number if this.context.largestObjectNumber + 1, so adding 10 ensures we won't skip current generade XRref Stream
+        this._lastXRefObjectNumber = this.context.largestObjectNumber + 10;
+        const checkWatermark = this._lastXRefObjectNumber - 20; // max number of objects in the final part of the PDF to check
         // search the last XRef Stream, if there is one, objects are expected to be in object number order
         for (let idx = objects.length - 1; idx > 0; idx--) {
           // if not in last 'rangeToCheck' objects, there is none that should be skipped, most probably a linearized PDF, or without XRef Streams

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -719,6 +719,33 @@ describe('PDFDocument', () => {
       const reloaded2 = await PDFDocument.load(noStmIB);
       expect(reloaded2.getPageCount()).toBe(pdfDoc.getPageCount());
     });
+
+    it('calculates correct pdf size', async () => {
+      const pdfDoc = await PDFDocument.load(v15PdfBytes);
+      const stmB = await pdfDoc.save();
+      const str = Buffer.from(stmB).toString();
+      let match = str.match(/Size(.*)/g);
+      expect(match?.length).toBe(1);
+      if (!match) return;
+      expect(match[0]).toBe('Size 16');
+      match = str.match(/Index(.*)/g);
+      if (!match) return;
+      expect(match[0]).toBe('Index [ 0 13 14 2 ]');
+      let tail = str.substring(str.length - 64);
+      tail = tail.substring(tail.indexOf('startxref') + 9).trim();
+      expect(tail.startsWith('3280')).toBeTruthy();
+      const noStmB = await pdfDoc.save({ useObjectStreams: false });
+      const noStrmStr = Buffer.from(noStmB).toString();
+      let matchNoStm = noStrmStr.match(/Size(.*)/g);
+      expect(matchNoStm?.length).toBe(1);
+      if (!matchNoStm) return;
+      expect(matchNoStm[0]).toBe('Size 13');
+      matchNoStm = noStrmStr.match(/Index(.*)/g);
+      expect(matchNoStm).toBeNull();
+      tail = noStrmStr.substring(str.length - 64);
+      tail = tail.substring(tail.indexOf('startxref') + 9).trim();
+      expect(tail.startsWith('3631')).toBeTruthy();
+    });
   });
 
   describe('saveIncremental() method', () => {


### PR DESCRIPTION
Added a test case to verify correct size calculation.
Modified PDFStreamWriter to use the shouldSave inherited method.
Fixed XrefStream skipping logic.

In PDFStreamWriter a conditional was added to skip XRef Streams that should be removed, when this is merged.