### PR TITLE
Fix regex for decoding PDF names to be case-insensitive

### DIFF
--- a/src/core/objects/PDFName.ts
+++ b/src/core/objects/PDFName.ts
@@ -10,7 +10,7 @@ import {
 } from '../../utils';
 
 const decodeName = (name: string) =>
-  name.replace(/#([\dABCDEF]{2})/g, (_, hex) => charFromHexCode(hex));
+  name.replace(/#([\dABCDEF]{2})/gi, (_, hex) => charFromHexCode(hex));
 
 const isRegularChar = (charCode: number) =>
   charCode >= CharCodes.ExclamationPoint &&


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->


## What?

Fix the `decodeName` regex in `PDFName.ts` to be case-insensitive when matching hex-encoded characters in PDF name objects.

## Why?

The PDF specification (ISO 32000-1, section 7.3.5) talks about hex digits in name escape sequences. Hex shouldn't differentiate between uppercase and lowercase (e.g., `#6d` and `#6D` both represent the byte `0x6D`). The existing regex only matched uppercase hex letters `A-F`, causing names with lowercase hex escapes to be silently corrupted through double-encoding.

For example, a name `/na#6de` (which should decode to `/name`) would fail to match the regex, leave the `#` literal in the decoded string, and then the constructor would re-encode it as `/na#236de` — a completely different and invalid name. This causes downstream dictionary lookups to silently fail, which can break page tree traversal, stream type detection, and other operations when reading PDFs produced by tools that emit lowercase hex in name objects.

## How?

Added the `i` (case-insensitive) flag to the `decodeName` regex. This is the minimal change needed since the character class `[\dABCDEF]` already covers the uppercase range — the `i` flag extends it to match `a-f` as well.

## Testing?

Verified the fix against a real-world PDF that contained lowercase hex escapes in name objects, which was previously causing corrupted name lookups.

## New Dependencies?

No.

## Screenshots

N/A.

## Suggested Reading?

Yes — specifically section 7.3.5 (Name Objects) of the PDF specification, which defines the `#` hex escape syntax and does not restrict hex digits to a specific case.

## Anything Else?

**AI disclosure:** The root cause of this bug was identified with the assistance of Claude Code. I encountered a problem with one of my PDFs and asked Claude to investigate the cause, which led to pinpointing the case-sensitive regex as the issue.

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.