### PR TITLE
fix: sort embedded file name tree entries

### DIFF
--- a/src/api/PDFEmbeddedFile.ts
+++ b/src/api/PDFEmbeddedFile.ts
@@ -1,7 +1,22 @@
 import Embeddable from './Embeddable';
 import PDFDocument from './PDFDocument';
 import FileEmbedder from '../core/embedders/FileEmbedder';
-import { PDFName, PDFArray, PDFDict, PDFHexString, PDFRef } from '../core';
+import {
+  PDFName,
+  PDFArray,
+  PDFDict,
+  PDFHexString,
+  PDFRef,
+  PDFString,
+} from '../core';
+
+const compareBytes = (left: Uint8Array, right: Uint8Array): number => {
+  const length = Math.min(left.length, right.length);
+  for (let idx = 0; idx < length; idx++) {
+    if (left[idx] !== right[idx]) return left[idx] - right[idx];
+  }
+  return left.length - right.length;
+};
 
 /**
  * Represents a file that has been embedded in a [[PDFDocument]].
@@ -67,8 +82,20 @@ export default class PDFEmbeddedFile implements Embeddable {
       }
       const EFNames = EmbeddedFiles.lookup(PDFName.of('Names'), PDFArray);
 
-      EFNames.push(PDFHexString.fromText(this.embedder.fileName));
-      EFNames.push(ref);
+      const fileName = PDFHexString.fromText(this.embedder.fileName);
+      const fileNameBytes = fileName.asBytes();
+      let insertionIndex = EFNames.size();
+
+      for (let idx = 0, len = EFNames.size(); idx < len; idx += 2) {
+        const existingFileName = EFNames.lookup(idx, PDFString, PDFHexString);
+        if (compareBytes(fileNameBytes, existingFileName.asBytes()) < 0) {
+          insertionIndex = idx;
+          break;
+        }
+      }
+
+      EFNames.insert(insertionIndex, fileName);
+      EFNames.insert(insertionIndex + 1, ref);
 
       /**
        * The AF-Tag is needed to achieve PDF-A3 compliance for embedded files

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -1664,6 +1664,24 @@ describe('PDFDocument', () => {
   });
 
   describe('attach() method', () => {
+    it('Sorts attachment names lexically', async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      await pdfDoc.attach(new Uint8Array(), '1.jpg');
+      await pdfDoc.attach(new Uint8Array(), '2.jpg');
+      await pdfDoc.attach(new Uint8Array(), '10.jpg');
+      await pdfDoc.save();
+
+      const Names = pdfDoc.catalog.lookup(PDFName.of('Names'), PDFDict);
+      const EmbeddedFiles = Names.lookup(PDFName.of('EmbeddedFiles'), PDFDict);
+      const EFNames = EmbeddedFiles.lookup(PDFName.of('Names'), PDFArray);
+      const names = [0, 2, 4].map((idx) =>
+        EFNames.lookup(idx, PDFHexString).decodeText(),
+      );
+
+      expect(names).toEqual(['1.jpg', '10.jpg', '2.jpg']);
+    });
+
     it('Saves to the same value after attaching a file', async () => {
       const pdfDoc1 = await PDFDocument.create({ updateMetadata: false });
       const pdfDoc2 = await PDFDocument.create({ updateMetadata: false });


### PR DESCRIPTION
## What?

Keeps `EmbeddedFiles` name-tree keys sorted by their encoded PDF bytes.

## Why?

Acrobat rejects some attachments when names such as `1.jpg`, `2.jpg`, and `10.jpg` are stored out of order.

## How?

The attachment key and reference are inserted at the correct byte-sorted position in the name tree.

## Testing?

Ran the full unit suite (804 passed, 1 skipped), typecheck, ESLint, Prettier, and the full build. A targeted Node check and real Chrome and Firefox browser checks verified byte-sorted attachment names in both a newly created PDF and an existing fixture. Chrome's PDF viewer rendered both generated documents. Deno and the complete desktop viewer matrix were not run.

## New Dependencies?

No.

## Screenshots

N/A.

## Suggested Reading?

No.

## Anything Else?

Closes #89.

## Checklist

- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [x] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
